### PR TITLE
fix: use audio media uri and default order

### DIFF
--- a/android/app/src/main/java/com/displaynone/lissn/MusicLibraryConstants.kt
+++ b/android/app/src/main/java/com/displaynone/lissn/MusicLibraryConstants.kt
@@ -16,11 +16,15 @@ const val ERROR_NO_PERMISSIONS_MESSAGE = "Missing MEDIA_LIBRARY permissions."
 const val ERROR_NO_WRITE_PERMISSION_MESSAGE = "Missing MEDIA_LIBRARY write permission."
 const val ERROR_USER_DID_NOT_GRANT_WRITE_PERMISSIONS_MESSAGE = "User didn't grant write permission to requested files."
 
-val EXTERNAL_CONTENT_URI: Uri = MediaStore.Files.getContentUri("external")
+// Use the audio specific content URI so we have access to all audio columns
+// such as `title_key` which is required by DEFAULT_SORT_ORDER
+val EXTERNAL_CONTENT_URI: Uri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
 
 val ASSET_PROJECTION = arrayOf(
   MediaStore.Audio.Media._ID,
   MediaStore.Audio.Media.TITLE,
+  // Needed for DEFAULT_SORT_ORDER which uses this column
+  MediaStore.Audio.Media.TITLE_KEY,
   MediaStore.Audio.Media.ARTIST,
   MediaStore.Audio.Media.DISPLAY_NAME,
   MediaStore.Audio.Media.DATE_ADDED,
@@ -28,9 +32,10 @@ val ASSET_PROJECTION = arrayOf(
   MediaStore.Audio.Media.DURATION,
   MediaStore.Audio.Media.DATA,
   MediaStore.Audio.Media.ALBUM, // Add album name for consistency
-  MediaStore.Audio.Albums._ID,
-  MediaStore.Audio.Artists._ID,
-  MediaStore.Audio.Genres._ID,
+  // Use IDs directly from Media table
+  MediaStore.Audio.Media.ALBUM_ID,
+  MediaStore.Audio.Media.ARTIST_ID,
+  MediaStore.Audio.Media.GENRE_ID,
 )
 
 val ALBUM_PROJECTION = arrayOf(

--- a/android/app/src/main/java/com/displaynone/lissn/assets/AssetUtils.kt
+++ b/android/app/src/main/java/com/displaynone/lissn/assets/AssetUtils.kt
@@ -29,9 +29,9 @@ fun putAssetsInfo(
     val durationIndex = cursor.getColumnIndex(MediaStore.Audio.Media.DURATION)
     val localUriIndex = cursor.getColumnIndex(MediaStore.Audio.Media.DATA)
     val albumNameIndex = cursor.getColumnIndex(MediaStore.Audio.Media.ALBUM)
-    val albumIdIndex = cursor.getColumnIndex(MediaStore.Audio.Albums._ID)
-    val artistIdIndex = cursor.getColumnIndex(MediaStore.Audio.Artists._ID)
-    val genreIdIndex = cursor.getColumnIndex(MediaStore.Audio.Genres._ID)
+    val albumIdIndex = cursor.getColumnIndex(MediaStore.Audio.Media.ALBUM_ID)
+    val artistIdIndex = cursor.getColumnIndex(MediaStore.Audio.Media.ARTIST_ID)
+    val genreIdIndex = cursor.getColumnIndex(MediaStore.Audio.Media.GENRE_ID)
 
     if (!cursor.moveToPosition(offset)) {
         return
@@ -83,9 +83,9 @@ fun fillAssetBundle(
     val durationIndex = cursor.getColumnIndex(MediaStore.Audio.Media.DURATION)
     val localUriIndex = cursor.getColumnIndex(MediaStore.Audio.Media.DATA)
     val albumNameIndex = cursor.getColumnIndex(MediaStore.Audio.Media.ALBUM)
-    val albumIdIndex = cursor.getColumnIndex(MediaStore.Audio.Albums._ID)
-    val artistIdIndex = cursor.getColumnIndex(MediaStore.Audio.Artists._ID)
-    val genreIdIndex = cursor.getColumnIndex(MediaStore.Audio.Genres._ID)
+    val albumIdIndex = cursor.getColumnIndex(MediaStore.Audio.Media.ALBUM_ID)
+    val artistIdIndex = cursor.getColumnIndex(MediaStore.Audio.Media.ARTIST_ID)
+    val genreIdIndex = cursor.getColumnIndex(MediaStore.Audio.Media.GENRE_ID)
 
     while (cursor.moveToNext()) {
         val assetId = cursor.getString(idIndex)

--- a/android/app/src/main/java/com/displaynone/lissn/assets/GetAssetsQuery.kt
+++ b/android/app/src/main/java/com/displaynone/lissn/assets/GetAssetsQuery.kt
@@ -43,7 +43,8 @@ private fun createSelectionString(input: AssetsOptions): String {
         selectionBuilder.append(" AND ")
     }
     selectionBuilder.append(
-        "${MediaStore.Files.FileColumns.MEDIA_TYPE} = ${MediaStore.Files.FileColumns.MEDIA_TYPE_AUDIO}"
+        // Ensure we only query music files when using the audio media table
+        "${MediaStore.Audio.Media.IS_MUSIC} != 0"
     )
 
     input.createdAfter?.let {


### PR DESCRIPTION
## Summary
- query audio using `MediaStore.Audio.Media.EXTERNAL_CONTENT_URI`
- include `TITLE_KEY` and media IDs in asset projection
- ensure we only fetch music files when building queries

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: expo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689866ed15308330a07f67b8f022626b