### PR TITLE
Open app from media notification

### DIFF
--- a/android/app/src/main/java/com/displaynone/lissn/AudioNotificationService.kt
+++ b/android/app/src/main/java/com/displaynone/lissn/AudioNotificationService.kt
@@ -135,12 +135,24 @@ class AudioNotificationService : Service() {
     private fun showOrUpdateNotification() {
         val smallIconId = resolveSmallIcon()
 
+        val openAppIntent = Intent(Intent.ACTION_VIEW, Uri.parse("lissn://song/playing")).apply {
+            setPackage(packageName)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        }
+        val contentPendingIntent = PendingIntent.getActivity(
+            this,
+            0,
+            openAppIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
         val builder = NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle(lastTitle)
             .setContentText(lastArtist)
             .setSmallIcon(smallIconId)
             .setOngoing(true)
             .setOnlyAlertOnce(true)
+            .setContentIntent(contentPendingIntent)
             .setStyle(
                 MediaStyle()
                     .setMediaSession(mediaSessionHelper.sessionToken)

--- a/app.json
+++ b/app.json
@@ -12,19 +12,31 @@
 			"supportsTablet": true,
 			"bundleIdentifier": "com.displaynone.lissn"
 		},
-		"android": {
-			"adaptiveIcon": {
-				"foregroundImage": "./assets/images/adaptive-icon.png",
-				"backgroundColor": "#ffffff"
-			},
-			"edgeToEdgeEnabled": true,
-			"permissions": [
-				"android.permission.READ_EXTERNAL_STORAGE",
-				"android.permission.WRITE_EXTERNAL_STORAGE",
-				"android.permission.ACCESS_MEDIA_LOCATION"
-			],
-			"package": "com.displaynone.lissn"
-		},
+                "android": {
+                        "adaptiveIcon": {
+                                "foregroundImage": "./assets/images/adaptive-icon.png",
+                                "backgroundColor": "#ffffff"
+                        },
+                        "edgeToEdgeEnabled": true,
+                        "permissions": [
+                                "android.permission.READ_EXTERNAL_STORAGE",
+                                "android.permission.WRITE_EXTERNAL_STORAGE",
+                                "android.permission.ACCESS_MEDIA_LOCATION"
+                        ],
+                        "package": "com.displaynone.lissn",
+                        "intentFilters": [
+                                {
+                                        "action": "VIEW",
+                                        "data": [
+                                                {
+                                                        "scheme": "lissn",
+                                                        "host": "*"
+                                                }
+                                        ],
+                                        "category": ["BROWSABLE", "DEFAULT"]
+                                }
+                        ]
+                },
 		"web": {
 			"bundler": "metro",
 			"output": "static",


### PR DESCRIPTION
## Summary
- Open app to `/song/playing` when tapping Android media notification
- Add Android intent filter so the app accepts `lissn://` deep links

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: expo not found)*
- `cd android && ./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6898c4fd4fc88330b2fa7abe78932fb9