### PR TITLE
feat: add bottom navigation

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -4,6 +4,7 @@ import { StatusBar } from "expo-status-bar";
 import "react-native-reanimated";
 
 import AppContainer from "@/components/AppContainer";
+import BottomNavigation from "@/components/partials/BottomNavigation";
 import { AudioLibraryProvider } from "@/hooks/providers/MediaLibraryProvider";
 import { initPlayerNotificationBridge } from "@/store/usePlayerStore";
 import { tamaguiConfig } from "@/tamagui.config";
@@ -72,15 +73,18 @@ export default function RootLayout() {
 					<AppContainer>
 						<View style={{ height: insets.top, backgroundColor }} />
 						<StatusBar style="light" translucent />
-						<SafeAreaView
-							style={{ flex: 1, width: "100%" }}
-							edges={["left", "right", "bottom"]}
-						>
-							<Slot />
-						</SafeAreaView>
-					</AppContainer>
-				</GestureHandlerRootView>
-			</AudioLibraryProvider>
-		</TamaguiProvider>
+                                                <SafeAreaView
+                                                        style={{ flex: 1, width: "100%" }}
+                                                        edges={["left", "right", "bottom"]}
+                                                >
+                                                        <View style={{ flex: 1 }}>
+                                                                <Slot />
+                                                                <BottomNavigation />
+                                                        </View>
+                                                </SafeAreaView>
+                                        </AppContainer>
+                                </GestureHandlerRootView>
+                        </AudioLibraryProvider>
+                </TamaguiProvider>
 	);
 }

--- a/app/artists/index.tsx
+++ b/app/artists/index.tsx
@@ -1,0 +1,11 @@
+import { Text, YStack } from "tamagui";
+import Player from "@/components/partials/Player";
+
+export default function ArtistsScreen() {
+        return (
+                <YStack flex={1} justifyContent="center" alignItems="center">
+                        <Text>Artists</Text>
+                        <Player />
+                </YStack>
+        );
+}

--- a/app/playlists/index.tsx
+++ b/app/playlists/index.tsx
@@ -1,0 +1,11 @@
+import { Text, YStack } from "tamagui";
+import Player from "@/components/partials/Player";
+
+export default function PlaylistsScreen() {
+        return (
+                <YStack flex={1} justifyContent="center" alignItems="center">
+                        <Text>Playlists</Text>
+                        <Player />
+                </YStack>
+        );
+}

--- a/components/partials/BottomNavigation.tsx
+++ b/components/partials/BottomNavigation.tsx
@@ -1,0 +1,44 @@
+import { usePathname, useRouter } from "expo-router";
+import { XStack, Button } from "tamagui";
+import Ionicons from "@expo/vector-icons/Ionicons";
+
+const BottomNavigation = () => {
+        const pathname = usePathname();
+        const router = useRouter();
+
+        if (pathname === "/song/playing") return null;
+
+        return (
+                <XStack
+                        justifyContent="space-around"
+                        alignItems="center"
+                        padding="$4"
+                        backgroundColor="$background"
+                        position="absolute"
+                        bottom={0}
+                        left={0}
+                        right={0}
+                >
+                        <Button
+                                backgroundColor="transparent"
+                                onPress={() => router.push("/artists")}
+                        >
+                                <Ionicons name="people" size={24} color="white" />
+                        </Button>
+                        <Button
+                                backgroundColor="transparent"
+                                onPress={() => router.push("/")}
+                        >
+                                <Ionicons name="home" size={24} color="white" />
+                        </Button>
+                        <Button
+                                backgroundColor="transparent"
+                                onPress={() => router.push("/playlists")}
+                        >
+                                <Ionicons name="musical-notes" size={24} color="white" />
+                        </Button>
+                </XStack>
+        );
+};
+
+export default BottomNavigation;


### PR DESCRIPTION
## Summary
- add bottom navigation with home, artists, and playlists links
- integrate bottom navigation into root layout
- scaffold artists and playlists screens

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898c905ef60833082c3ba3099f21895