### PR TITLE
Update non-English translation files

### DIFF
--- a/locales/ar/messages.js
+++ b/locales/ar/messages.js
@@ -1,1 +1,1 @@
-/*eslint-disable*/module.exports={messages:JSON.parse("{\"X9kySA\":[\"Favorites\"],\"hGVdRx\":[\"Songs\"]}")};
+/*eslint-disable*/module.exports={messages:JSON.parse("{\"X9kySA\":[\"\u0627\u0644\u0645\u0641\u0636\u0644\u0629\"],\"hGVdRx\":[\"\u0623\u063a\u0627\u0646\u064a\"]}")};

--- a/locales/ar/messages.po
+++ b/locales/ar/messages.po
@@ -15,8 +15,8 @@ msgstr ""
 
 #: components/partials/Heading.tsx:16
 msgid "Favorites"
-msgstr ""
+msgstr "المفضلة"
 
 #: components/partials/Heading.tsx:14
 msgid "Songs"
-msgstr ""
+msgstr "أغاني"

--- a/locales/de/messages.js
+++ b/locales/de/messages.js
@@ -1,1 +1,1 @@
-/*eslint-disable*/module.exports={messages:JSON.parse("{\"X9kySA\":[\"Favorites\"],\"hGVdRx\":[\"Songs\"]}")};
+/*eslint-disable*/module.exports={messages:JSON.parse("{\"X9kySA\":[\"Favoriten\"],\"hGVdRx\":[\"Lieder\"]}")};

--- a/locales/de/messages.po
+++ b/locales/de/messages.po
@@ -15,8 +15,8 @@ msgstr ""
 
 #: components/partials/Heading.tsx:16
 msgid "Favorites"
-msgstr ""
+msgstr "Favoriten"
 
 #: components/partials/Heading.tsx:14
 msgid "Songs"
-msgstr ""
+msgstr "Lieder"

--- a/locales/es/messages.js
+++ b/locales/es/messages.js
@@ -1,1 +1,1 @@
-/*eslint-disable*/module.exports={messages:JSON.parse("{\"X9kySA\":[\"Favorites\"],\"hGVdRx\":[\"Songs\"]}")};
+/*eslint-disable*/module.exports={messages:JSON.parse("{\"X9kySA\":[\"Favoritos\"],\"hGVdRx\":[\"Canciones\"]}")};

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -15,8 +15,8 @@ msgstr ""
 
 #: components/partials/Heading.tsx:16
 msgid "Favorites"
-msgstr ""
+msgstr "Favoritos"
 
 #: components/partials/Heading.tsx:14
 msgid "Songs"
-msgstr ""
+msgstr "Canciones"

--- a/locales/fr/messages.js
+++ b/locales/fr/messages.js
@@ -1,1 +1,1 @@
-/*eslint-disable*/module.exports={messages:JSON.parse("{\"X9kySA\":[\"Favorites\"],\"hGVdRx\":[\"Songs\"]}")};
+/*eslint-disable*/module.exports={messages:JSON.parse("{\"X9kySA\":[\"Favoris\"],\"hGVdRx\":[\"Chansons\"]}")};

--- a/locales/fr/messages.po
+++ b/locales/fr/messages.po
@@ -15,8 +15,8 @@ msgstr ""
 
 #: components/partials/Heading.tsx:16
 msgid "Favorites"
-msgstr ""
+msgstr "Favoris"
 
 #: components/partials/Heading.tsx:14
 msgid "Songs"
-msgstr ""
+msgstr "Chansons"

--- a/locales/hi/messages.js
+++ b/locales/hi/messages.js
@@ -1,1 +1,1 @@
-/*eslint-disable*/module.exports={messages:JSON.parse("{\"X9kySA\":[\"Favorites\"],\"hGVdRx\":[\"Songs\"]}")};
+/*eslint-disable*/module.exports={messages:JSON.parse("{\"X9kySA\":[\"\u092a\u0938\u0902\u0926\u0940\u0926\u093e\"],\"hGVdRx\":[\"\u0917\u0940\u0924\"]}")};

--- a/locales/hi/messages.po
+++ b/locales/hi/messages.po
@@ -15,8 +15,8 @@ msgstr ""
 
 #: components/partials/Heading.tsx:16
 msgid "Favorites"
-msgstr ""
+msgstr "पसंदीदा"
 
 #: components/partials/Heading.tsx:14
 msgid "Songs"
-msgstr ""
+msgstr "गीत"

--- a/locales/it/messages.js
+++ b/locales/it/messages.js
@@ -1,1 +1,1 @@
-/*eslint-disable*/module.exports={messages:JSON.parse("{\"X9kySA\":[\"Favorites\"],\"hGVdRx\":[\"Songs\"]}")};
+/*eslint-disable*/module.exports={messages:JSON.parse("{\"X9kySA\":[\"Preferiti\"],\"hGVdRx\":[\"Canzoni\"]}")};

--- a/locales/it/messages.po
+++ b/locales/it/messages.po
@@ -15,8 +15,8 @@ msgstr ""
 
 #: components/partials/Heading.tsx:16
 msgid "Favorites"
-msgstr ""
+msgstr "Preferiti"
 
 #: components/partials/Heading.tsx:14
 msgid "Songs"
-msgstr ""
+msgstr "Canzoni"

--- a/locales/ja/messages.js
+++ b/locales/ja/messages.js
@@ -1,1 +1,1 @@
-/*eslint-disable*/module.exports={messages:JSON.parse("{\"X9kySA\":[\"Favorites\"],\"hGVdRx\":[\"Songs\"]}")};
+/*eslint-disable*/module.exports={messages:JSON.parse("{\"X9kySA\":[\"\u304a\u6c17\u306b\u5165\u308a\"],\"hGVdRx\":[\"\u66f2\"]}")};

--- a/locales/ja/messages.po
+++ b/locales/ja/messages.po
@@ -15,8 +15,8 @@ msgstr ""
 
 #: components/partials/Heading.tsx:16
 msgid "Favorites"
-msgstr ""
+msgstr "お気に入り"
 
 #: components/partials/Heading.tsx:14
 msgid "Songs"
-msgstr ""
+msgstr "曲"

--- a/locales/ko/messages.js
+++ b/locales/ko/messages.js
@@ -1,1 +1,1 @@
-/*eslint-disable*/module.exports={messages:JSON.parse("{\"X9kySA\":[\"Favorites\"],\"hGVdRx\":[\"Songs\"]}")};
+/*eslint-disable*/module.exports={messages:JSON.parse("{\"X9kySA\":[\"\uc990\uaca8\ucc3e\uae30\"],\"hGVdRx\":[\"\ub178\ub798\"]}")};

--- a/locales/ko/messages.po
+++ b/locales/ko/messages.po
@@ -15,8 +15,8 @@ msgstr ""
 
 #: components/partials/Heading.tsx:16
 msgid "Favorites"
-msgstr ""
+msgstr "즐겨찾기"
 
 #: components/partials/Heading.tsx:14
 msgid "Songs"
-msgstr ""
+msgstr "노래"

--- a/locales/zh/messages.js
+++ b/locales/zh/messages.js
@@ -1,1 +1,1 @@
-/*eslint-disable*/module.exports={messages:JSON.parse("{\"X9kySA\":[\"Favorites\"],\"hGVdRx\":[\"Songs\"]}")};
+/*eslint-disable*/module.exports={messages:JSON.parse("{\"X9kySA\":[\"\u6536\u85cf\u5939\"],\"hGVdRx\":[\"\u6b4c\u66f2\"]}")};

--- a/locales/zh/messages.po
+++ b/locales/zh/messages.po
@@ -15,8 +15,8 @@ msgstr ""
 
 #: components/partials/Heading.tsx:16
 msgid "Favorites"
-msgstr ""
+msgstr "收藏夹"
 
 #: components/partials/Heading.tsx:14
 msgid "Songs"
-msgstr ""
+msgstr "歌曲"


### PR DESCRIPTION
## Summary
- translate "Favorites" and "Songs" for all locales
- regenerate message catalogs

## Testing
- `npm run lingui:compile` *(fails: lingui: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d18dce83c8330857933fa41c6b97e