### PR TITLE
chore: add missing Search songs translations

### DIFF
--- a/locales/ar/messages.po
+++ b/locales/ar/messages.po
@@ -19,7 +19,7 @@ msgstr "المفضلة"
 
 #: components/partials/Heading.tsx:69
 msgid "Search songs"
-msgstr ""
+msgstr "ابحث عن الأغاني"
 
 #: components/partials/Heading.tsx:31
 msgid "Songs"

--- a/locales/de/messages.po
+++ b/locales/de/messages.po
@@ -19,7 +19,7 @@ msgstr "Favoriten"
 
 #: components/partials/Heading.tsx:69
 msgid "Search songs"
-msgstr ""
+msgstr "Lieder suchen"
 
 #: components/partials/Heading.tsx:31
 msgid "Songs"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -19,7 +19,7 @@ msgstr "Favoritos"
 
 #: components/partials/Heading.tsx:69
 msgid "Search songs"
-msgstr ""
+msgstr "Buscar canciones"
 
 #: components/partials/Heading.tsx:31
 msgid "Songs"

--- a/locales/fr/messages.po
+++ b/locales/fr/messages.po
@@ -19,7 +19,7 @@ msgstr "Favoris"
 
 #: components/partials/Heading.tsx:69
 msgid "Search songs"
-msgstr ""
+msgstr "Rechercher des chansons"
 
 #: components/partials/Heading.tsx:31
 msgid "Songs"

--- a/locales/hi/messages.po
+++ b/locales/hi/messages.po
@@ -19,7 +19,7 @@ msgstr "पसंदीदा"
 
 #: components/partials/Heading.tsx:69
 msgid "Search songs"
-msgstr ""
+msgstr "गीत खोजें"
 
 #: components/partials/Heading.tsx:31
 msgid "Songs"

--- a/locales/it/messages.po
+++ b/locales/it/messages.po
@@ -19,7 +19,7 @@ msgstr "Preferiti"
 
 #: components/partials/Heading.tsx:69
 msgid "Search songs"
-msgstr ""
+msgstr "Cerca canzoni"
 
 #: components/partials/Heading.tsx:31
 msgid "Songs"

--- a/locales/ja/messages.po
+++ b/locales/ja/messages.po
@@ -19,7 +19,7 @@ msgstr "お気に入り"
 
 #: components/partials/Heading.tsx:69
 msgid "Search songs"
-msgstr ""
+msgstr "曲を検索"
 
 #: components/partials/Heading.tsx:31
 msgid "Songs"

--- a/locales/ko/messages.po
+++ b/locales/ko/messages.po
@@ -19,7 +19,7 @@ msgstr "즐겨찾기"
 
 #: components/partials/Heading.tsx:69
 msgid "Search songs"
-msgstr ""
+msgstr "노래 검색"
 
 #: components/partials/Heading.tsx:31
 msgid "Songs"

--- a/locales/zh/messages.po
+++ b/locales/zh/messages.po
@@ -19,7 +19,7 @@ msgstr "收藏夹"
 
 #: components/partials/Heading.tsx:69
 msgid "Search songs"
-msgstr ""
+msgstr "搜索歌曲"
 
 #: components/partials/Heading.tsx:31
 msgid "Songs"


### PR DESCRIPTION
## Summary
- add missing "Search songs" translation to all locales

## Testing
- `npm run lingui:compile` *(fails: 403 Forbidden fetching @lingui/cli)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: expo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e18d2202c83309981011ca2d10d8d