### PR TITLE
chore: sync non-English locales with English messages

### DIFF
--- a/locales/ar/messages.po
+++ b/locales/ar/messages.po
@@ -19,7 +19,7 @@ msgstr "المفضلة"
 
 #: components/partials/DrawerContent.tsx:41
 msgid "GitHub Project"
-msgstr ""
+msgstr "GitHub Project"
 
 #: components/partials/Heading.tsx:77
 msgid "Search songs"
@@ -31,4 +31,4 @@ msgstr "أغاني"
 
 #: components/partials/DrawerContent.tsx:26
 msgid "Your music app"
-msgstr ""
+msgstr "Your music app"

--- a/locales/de/messages.po
+++ b/locales/de/messages.po
@@ -19,7 +19,7 @@ msgstr "Favoriten"
 
 #: components/partials/DrawerContent.tsx:41
 msgid "GitHub Project"
-msgstr ""
+msgstr "GitHub Project"
 
 #: components/partials/Heading.tsx:77
 msgid "Search songs"
@@ -31,4 +31,4 @@ msgstr "Lieder"
 
 #: components/partials/DrawerContent.tsx:26
 msgid "Your music app"
-msgstr ""
+msgstr "Your music app"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -19,7 +19,7 @@ msgstr "Favoritos"
 
 #: components/partials/DrawerContent.tsx:41
 msgid "GitHub Project"
-msgstr ""
+msgstr "GitHub Project"
 
 #: components/partials/Heading.tsx:77
 msgid "Search songs"
@@ -31,4 +31,4 @@ msgstr "Canciones"
 
 #: components/partials/DrawerContent.tsx:26
 msgid "Your music app"
-msgstr ""
+msgstr "Your music app"

--- a/locales/fr/messages.po
+++ b/locales/fr/messages.po
@@ -19,7 +19,7 @@ msgstr "Favoris"
 
 #: components/partials/DrawerContent.tsx:41
 msgid "GitHub Project"
-msgstr ""
+msgstr "GitHub Project"
 
 #: components/partials/Heading.tsx:77
 msgid "Search songs"
@@ -31,4 +31,4 @@ msgstr "Chansons"
 
 #: components/partials/DrawerContent.tsx:26
 msgid "Your music app"
-msgstr ""
+msgstr "Your music app"

--- a/locales/hi/messages.po
+++ b/locales/hi/messages.po
@@ -19,7 +19,7 @@ msgstr "पसंदीदा"
 
 #: components/partials/DrawerContent.tsx:41
 msgid "GitHub Project"
-msgstr ""
+msgstr "GitHub Project"
 
 #: components/partials/Heading.tsx:77
 msgid "Search songs"
@@ -31,4 +31,4 @@ msgstr "गीत"
 
 #: components/partials/DrawerContent.tsx:26
 msgid "Your music app"
-msgstr ""
+msgstr "Your music app"

--- a/locales/it/messages.po
+++ b/locales/it/messages.po
@@ -19,7 +19,7 @@ msgstr "Preferiti"
 
 #: components/partials/DrawerContent.tsx:41
 msgid "GitHub Project"
-msgstr ""
+msgstr "GitHub Project"
 
 #: components/partials/Heading.tsx:77
 msgid "Search songs"
@@ -31,4 +31,4 @@ msgstr "Canzoni"
 
 #: components/partials/DrawerContent.tsx:26
 msgid "Your music app"
-msgstr ""
+msgstr "Your music app"

--- a/locales/ja/messages.po
+++ b/locales/ja/messages.po
@@ -19,7 +19,7 @@ msgstr "お気に入り"
 
 #: components/partials/DrawerContent.tsx:41
 msgid "GitHub Project"
-msgstr ""
+msgstr "GitHub Project"
 
 #: components/partials/Heading.tsx:77
 msgid "Search songs"
@@ -31,4 +31,4 @@ msgstr "曲"
 
 #: components/partials/DrawerContent.tsx:26
 msgid "Your music app"
-msgstr ""
+msgstr "Your music app"

--- a/locales/ko/messages.po
+++ b/locales/ko/messages.po
@@ -19,7 +19,7 @@ msgstr "즐겨찾기"
 
 #: components/partials/DrawerContent.tsx:41
 msgid "GitHub Project"
-msgstr ""
+msgstr "GitHub Project"
 
 #: components/partials/Heading.tsx:77
 msgid "Search songs"
@@ -31,4 +31,4 @@ msgstr "노래"
 
 #: components/partials/DrawerContent.tsx:26
 msgid "Your music app"
-msgstr ""
+msgstr "Your music app"

--- a/locales/zh/messages.po
+++ b/locales/zh/messages.po
@@ -19,7 +19,7 @@ msgstr "收藏夹"
 
 #: components/partials/DrawerContent.tsx:41
 msgid "GitHub Project"
-msgstr ""
+msgstr "GitHub Project"
 
 #: components/partials/Heading.tsx:77
 msgid "Search songs"
@@ -31,4 +31,4 @@ msgstr "歌曲"
 
 #: components/partials/DrawerContent.tsx:26
 msgid "Your music app"
-msgstr ""
+msgstr "Your music app"


### PR DESCRIPTION
## Summary
- fill missing `GitHub Project` and `Your music app` strings across non-English locales using English placeholders

## Testing
- `npm run lingui:compile` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lingui)*

------
https://chatgpt.com/codex/tasks/task_e_689e6adc935883309ab69dc74ce42955