### PR TITLE
chore: update translations

### DIFF
--- a/locales/ar/messages.po
+++ b/locales/ar/messages.po
@@ -23,11 +23,11 @@ msgstr "مشروع GitHub"
 
 #: app/index.tsx:171
 msgid "Last songs"
-msgstr ""
+msgstr "أحدث الأغاني"
 
 #: app/index.tsx:156
 msgid "Recently played"
-msgstr ""
+msgstr "تم تشغيلها مؤخراً"
 
 #: components/partials/Heading.tsx:75
 msgid "Search songs"

--- a/locales/de/messages.po
+++ b/locales/de/messages.po
@@ -23,11 +23,11 @@ msgstr "GitHub-Projekt"
 
 #: app/index.tsx:171
 msgid "Last songs"
-msgstr ""
+msgstr "Letzte Songs"
 
 #: app/index.tsx:156
 msgid "Recently played"
-msgstr ""
+msgstr "Kürzlich gespielt"
 
 #: components/partials/Heading.tsx:75
 msgid "Search songs"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -23,11 +23,11 @@ msgstr "Proyecto de GitHub"
 
 #: app/index.tsx:171
 msgid "Last songs"
-msgstr ""
+msgstr "Últimas canciones"
 
 #: app/index.tsx:156
 msgid "Recently played"
-msgstr ""
+msgstr "Reproducidas recientemente"
 
 #: components/partials/Heading.tsx:75
 msgid "Search songs"

--- a/locales/fr/messages.po
+++ b/locales/fr/messages.po
@@ -23,11 +23,11 @@ msgstr "Projet GitHub"
 
 #: app/index.tsx:171
 msgid "Last songs"
-msgstr ""
+msgstr "Dernières chansons"
 
 #: app/index.tsx:156
 msgid "Recently played"
-msgstr ""
+msgstr "Récemment jouées"
 
 #: components/partials/Heading.tsx:75
 msgid "Search songs"

--- a/locales/hi/messages.po
+++ b/locales/hi/messages.po
@@ -23,11 +23,11 @@ msgstr "GitHub परियोजना"
 
 #: app/index.tsx:171
 msgid "Last songs"
-msgstr ""
+msgstr "नवीनतम गीत"
 
 #: app/index.tsx:156
 msgid "Recently played"
-msgstr ""
+msgstr "हाल ही में चलाए गए"
 
 #: components/partials/Heading.tsx:75
 msgid "Search songs"

--- a/locales/it/messages.po
+++ b/locales/it/messages.po
@@ -23,11 +23,11 @@ msgstr "Progetto GitHub"
 
 #: app/index.tsx:171
 msgid "Last songs"
-msgstr ""
+msgstr "Ultime canzoni"
 
 #: app/index.tsx:156
 msgid "Recently played"
-msgstr ""
+msgstr "Riprodotte di recente"
 
 #: components/partials/Heading.tsx:75
 msgid "Search songs"

--- a/locales/ja/messages.po
+++ b/locales/ja/messages.po
@@ -23,11 +23,11 @@ msgstr "GitHub プロジェクト"
 
 #: app/index.tsx:171
 msgid "Last songs"
-msgstr ""
+msgstr "最新の曲"
 
 #: app/index.tsx:156
 msgid "Recently played"
-msgstr ""
+msgstr "最近再生した曲"
 
 #: components/partials/Heading.tsx:75
 msgid "Search songs"

--- a/locales/ko/messages.po
+++ b/locales/ko/messages.po
@@ -23,11 +23,11 @@ msgstr "GitHub 프로젝트"
 
 #: app/index.tsx:171
 msgid "Last songs"
-msgstr ""
+msgstr "최신 곡"
 
 #: app/index.tsx:156
 msgid "Recently played"
-msgstr ""
+msgstr "최근 재생한 곡"
 
 #: components/partials/Heading.tsx:75
 msgid "Search songs"

--- a/locales/zh/messages.po
+++ b/locales/zh/messages.po
@@ -23,11 +23,11 @@ msgstr "GitHub 项目"
 
 #: app/index.tsx:171
 msgid "Last songs"
-msgstr ""
+msgstr "最新歌曲"
 
 #: app/index.tsx:156
 msgid "Recently played"
-msgstr ""
+msgstr "最近播放"
 
 #: components/partials/Heading.tsx:75
 msgid "Search songs"


### PR DESCRIPTION
## Summary
- fill missing "Last songs" and "Recently played" translations for all non-English locales

## Testing
- `npm run lingui:compile` *(fails: 403 Forbidden fetching lingui)*
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fb2e950b883308f0e614c5950dff3