### PR TITLE
chore: update translations

### DIFF
--- a/locales/ar/messages.po
+++ b/locales/ar/messages.po
@@ -1,16 +1,16 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2025-08-14 00:43+0200\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"X-Generator: @lingui/cli\n"
-"Language: ar\n"
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 00:43+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: ar\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
 "Plural-Forms: \n"
 
 #: components/partials/SongInfo.tsx:151
@@ -21,8 +21,7 @@ msgstr "أضف إلى المفضلة"
 msgid "Add to playlist"
 msgstr "أضف إلى قائمة التشغيل"
 
-#: app/song/edit/[id].tsx:162
-#: components/partials/SongInfo.tsx:114
+#: app/song/edit/[id].tsx:162 components/partials/SongInfo.tsx:114
 msgid "Album"
 msgstr "ألبوم"
 
@@ -46,8 +45,7 @@ msgstr ""
 msgid "Are you sure you want to delete the song?"
 msgstr ""
 
-#: app/song/edit/[id].tsx:131
-#: components/partials/SongInfo.tsx:108
+#: app/song/edit/[id].tsx:131 components/partials/SongInfo.tsx:108
 msgid "Artist"
 msgstr "فنان"
 
@@ -67,22 +65,16 @@ msgstr "فنانون"
 msgid "Artists merged"
 msgstr "تم دمج الفنانين"
 
-#: app/albums/edit/[id].tsx:103
-#: app/albums/new.tsx:97
-#: app/artists/edit/[id].tsx:103
-#: app/artists/new.tsx:97
+#: app/albums/edit/[id].tsx:103 app/albums/new.tsx:97
+#: app/artists/edit/[id].tsx:103 app/artists/new.tsx:97
 #: app/song/edit/[id].tsx:106
 msgid "Artwork URL"
 msgstr "رابط الصورة"
 
-#: app/albums/edit/[id].tsx:225
-#: app/albums/edit/[id].tsx:301
-#: app/albums/new.tsx:166
-#: app/artists/edit/[id].tsx:225
-#: app/artists/edit/[id].tsx:301
-#: app/artists/new.tsx:166
-#: app/song/edit/[id].tsx:262
-#: components/partials/SongInfo.tsx:216
+#: app/albums/edit/[id].tsx:225 app/albums/edit/[id].tsx:301
+#: app/albums/new.tsx:166 app/artists/edit/[id].tsx:225
+#: app/artists/edit/[id].tsx:301 app/artists/new.tsx:166
+#: app/song/edit/[id].tsx:262 components/partials/SongInfo.tsx:216
 msgid "Cancel"
 msgstr "إلغاء"
 
@@ -102,8 +94,7 @@ msgstr "تم استيراد قاعدة البيانات بنجاح"
 msgid "Delete"
 msgstr ""
 
-#: components/partials/SongInfo.tsx:176
-#: components/partials/SongInfo.tsx:186
+#: components/partials/SongInfo.tsx:176 components/partials/SongInfo.tsx:186
 msgid "Delete song"
 msgstr "حذف الأغنية"
 
@@ -140,8 +131,7 @@ msgstr "المفضلة"
 msgid "GitHub Project"
 msgstr "مشروع GitHub"
 
-#: utils/pickAndImportDB.ts:16
-#: utils/pickAndImportDB.ts:28
+#: utils/pickAndImportDB.ts:16 utils/pickAndImportDB.ts:28
 #: utils/pickAndImportDB.ts:34
 msgid "Import database"
 msgstr "استيراد قاعدة البيانات"
@@ -154,8 +144,7 @@ msgstr "استيراد قاعدة بيانات الموسيقى"
 msgid "Last songs"
 msgstr "آخر الأغاني"
 
-#: app/albums/edit/[id].tsx:291
-#: app/artists/edit/[id].tsx:291
+#: app/albums/edit/[id].tsx:291 app/artists/edit/[id].tsx:291
 msgid "Merge"
 msgstr "دمج"
 
@@ -167,30 +156,24 @@ msgstr ""
 msgid "Merge artists"
 msgstr "دمج الفنانين"
 
-#: app/albums/edit/[id].tsx:268
-#: app/artists/edit/[id].tsx:268
+#: app/albums/edit/[id].tsx:268 app/artists/edit/[id].tsx:268
 msgid "Merge them"
 msgstr "دمجهم"
 
-#: app/albums/edit/[id].tsx:269
-#: app/artists/edit/[id].tsx:269
+#: app/albums/edit/[id].tsx:269 app/artists/edit/[id].tsx:269
 msgid "Merging..."
 msgstr "جارٍ الدمج..."
 
-#: app/albums/edit/[id].tsx:82
-#: app/albums/new.tsx:76
-#: app/artists/edit/[id].tsx:82
-#: app/artists/new.tsx:76
+#: app/albums/edit/[id].tsx:82 app/albums/new.tsx:76
+#: app/artists/edit/[id].tsx:82 app/artists/new.tsx:76
 msgid "Name"
 msgstr "الاسم"
 
-#: app/albums/new.tsx:65
-#: app/albums/new.tsx:150
+#: app/albums/new.tsx:65 app/albums/new.tsx:150
 msgid "New album"
 msgstr ""
 
-#: app/artists/new.tsx:65
-#: app/artists/new.tsx:150
+#: app/artists/new.tsx:65 app/artists/new.tsx:150
 msgid "New artist"
 msgstr ""
 
@@ -210,10 +193,8 @@ msgstr ""
 msgid "Nombre del artista"
 msgstr "اسم الفنان"
 
-#: app/albums/edit/[id].tsx:50
-#: app/albums/new.tsx:36
-#: app/artists/edit/[id].tsx:50
-#: app/artists/new.tsx:36
+#: app/albums/edit/[id].tsx:50 app/albums/new.tsx:36
+#: app/artists/edit/[id].tsx:50 app/artists/new.tsx:36
 #: app/song/edit/[id].tsx:40
 msgid "Not valid URL"
 msgstr "عنوان URL غير صالح"
@@ -242,18 +223,14 @@ msgstr ""
 msgid "Same artist?"
 msgstr "نفس الفنان؟"
 
-#: app/albums/edit/[id].tsx:128
-#: app/albums/new.tsx:122
-#: app/artists/edit/[id].tsx:128
-#: app/artists/new.tsx:122
+#: app/albums/edit/[id].tsx:128 app/albums/new.tsx:122
+#: app/artists/edit/[id].tsx:128 app/artists/new.tsx:122
 #: app/song/edit/[id].tsx:193
 msgid "Save"
 msgstr "حفظ"
 
-#: app/albums/edit/[id].tsx:128
-#: app/albums/new.tsx:122
-#: app/artists/edit/[id].tsx:128
-#: app/artists/new.tsx:122
+#: app/albums/edit/[id].tsx:128 app/albums/new.tsx:122
+#: app/artists/edit/[id].tsx:128 app/artists/new.tsx:122
 #: app/song/edit/[id].tsx:193
 msgid "Saving..."
 msgstr "جارٍ الحفظ..."
@@ -262,8 +239,7 @@ msgstr "جارٍ الحفظ..."
 msgid "Search songs"
 msgstr "البحث عن الأغاني"
 
-#: components/ui/Select.tsx:54
-#: components/ui/Select.tsx:105
+#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
 msgid "Select an option"
 msgstr ""
 
@@ -271,8 +247,7 @@ msgstr ""
 msgid "Selection canceled"
 msgstr "تم إلغاء التحديد"
 
-#: components/partials/DrawerContent.tsx:53
-#: components/partials/Heading.tsx:41
+#: components/partials/DrawerContent.tsx:53 components/partials/Heading.tsx:41
 msgid "Settings"
 msgstr "الإعدادات"
 
@@ -284,8 +259,7 @@ msgstr ""
 msgid "Song update"
 msgstr ""
 
-#: app/albums/[id].tsx:88
-#: app/artists/[id].tsx:88
+#: app/albums/[id].tsx:88 app/artists/[id].tsx:88
 #: components/partials/Heading.tsx:35
 msgid "Songs"
 msgstr "أغانٍ"
@@ -298,8 +272,7 @@ msgstr ""
 msgid "The artists have been merged successfully"
 msgstr "تم دمج الفنانين بنجاح"
 
-#: app/artists/edit/[id].tsx:43
-#: app/artists/new.tsx:29
+#: app/artists/edit/[id].tsx:43 app/artists/new.tsx:29
 msgid "The name must have at least 2 characters"
 msgstr "يجب أن يحتوي الاسم على حرفين على الأقل"
 
@@ -307,42 +280,39 @@ msgstr "يجب أن يحتوي الاسم على حرفين على الأقل"
 msgid "The song has been updated correctly"
 msgstr ""
 
-#: app/albums/edit/[id].tsx:43
-#: app/albums/new.tsx:29
-#: app/song/edit/[id].tsx:33
+#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
 msgid "The title must have at least 2 characters"
 msgstr ""
 
 #: app/albums/edit/[id].tsx:237
-msgid "These albums share the same title because Android reads it from the ID3 tags, which you can edit in Lissn."
+msgid ""
+"These albums share the same title because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
 msgstr ""
 
 #: app/artists/edit/[id].tsx:237
-msgid "These artists share the same name because Android reads it from the ID3 tags, which you can edit in Lissn."
-msgstr "يشترك هؤلاء الفنانون في نفس الاسم لأن أندرويد يقرأه من وسوم ID3 التي يمكنك تعديلها في Lissn."
+msgid ""
+"These artists share the same name because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
+msgstr ""
+"يشترك هؤلاء الفنانون في نفس الاسم لأن أندرويد يقرأه من وسوم ID3 التي يمكنك "
+"تعديلها في Lissn."
 
-#: components/partials/SongInfo.tsx:97
-#~ msgid "Tile"
-#~ msgstr "لوحة"
-
-#: app/song/edit/[id].tsx:85
-#: components/partials/SongInfo.tsx:104
+#: app/song/edit/[id].tsx:85 components/partials/SongInfo.tsx:104
 msgid "Title"
 msgstr "العنوان"
 
-#: app/albums/edit/[id].tsx:44
-#: app/albums/edit/[id].tsx:47
-#: app/albums/new.tsx:30
-#: app/albums/new.tsx:33
-#: app/artists/edit/[id].tsx:44
-#: app/artists/edit/[id].tsx:47
-#: app/artists/new.tsx:30
-#: app/artists/new.tsx:33
-#: app/song/edit/[id].tsx:34
-#: app/song/edit/[id].tsx:37
+#: app/albums/edit/[id].tsx:44 app/albums/edit/[id].tsx:47
+#: app/albums/new.tsx:30 app/albums/new.tsx:33 app/artists/edit/[id].tsx:44
+#: app/artists/edit/[id].tsx:47 app/artists/new.tsx:30 app/artists/new.tsx:33
+#: app/song/edit/[id].tsx:34 app/song/edit/[id].tsx:37
 msgid "Too long"
 msgstr "طويل جداً"
 
 #: components/partials/DrawerContent.tsx:36
 msgid "Your music app"
 msgstr "تطبيق الموسيقى الخاص بك"
+
+#: components/partials/SongInfo.tsx:97
+#~ msgid "Tile"
+#~ msgstr "لوحة"

--- a/locales/de/messages.po
+++ b/locales/de/messages.po
@@ -1,16 +1,16 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2025-08-14 00:43+0200\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"X-Generator: @lingui/cli\n"
-"Language: de\n"
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 00:43+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
 "Plural-Forms: \n"
 
 #: components/partials/SongInfo.tsx:151
@@ -21,8 +21,7 @@ msgstr "Zu Favoriten hinzufügen"
 msgid "Add to playlist"
 msgstr "Zur Playlist hinzufügen"
 
-#: app/song/edit/[id].tsx:162
-#: components/partials/SongInfo.tsx:114
+#: app/song/edit/[id].tsx:162 components/partials/SongInfo.tsx:114
 msgid "Album"
 msgstr "Album"
 
@@ -46,8 +45,7 @@ msgstr ""
 msgid "Are you sure you want to delete the song?"
 msgstr ""
 
-#: app/song/edit/[id].tsx:131
-#: components/partials/SongInfo.tsx:108
+#: app/song/edit/[id].tsx:131 components/partials/SongInfo.tsx:108
 msgid "Artist"
 msgstr "Künstler"
 
@@ -67,22 +65,16 @@ msgstr "Künstler"
 msgid "Artists merged"
 msgstr "Künstler zusammengeführt"
 
-#: app/albums/edit/[id].tsx:103
-#: app/albums/new.tsx:97
-#: app/artists/edit/[id].tsx:103
-#: app/artists/new.tsx:97
+#: app/albums/edit/[id].tsx:103 app/albums/new.tsx:97
+#: app/artists/edit/[id].tsx:103 app/artists/new.tsx:97
 #: app/song/edit/[id].tsx:106
 msgid "Artwork URL"
 msgstr "Artwork-URL"
 
-#: app/albums/edit/[id].tsx:225
-#: app/albums/edit/[id].tsx:301
-#: app/albums/new.tsx:166
-#: app/artists/edit/[id].tsx:225
-#: app/artists/edit/[id].tsx:301
-#: app/artists/new.tsx:166
-#: app/song/edit/[id].tsx:262
-#: components/partials/SongInfo.tsx:216
+#: app/albums/edit/[id].tsx:225 app/albums/edit/[id].tsx:301
+#: app/albums/new.tsx:166 app/artists/edit/[id].tsx:225
+#: app/artists/edit/[id].tsx:301 app/artists/new.tsx:166
+#: app/song/edit/[id].tsx:262 components/partials/SongInfo.tsx:216
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -102,8 +94,7 @@ msgstr "Datenbank erfolgreich importiert"
 msgid "Delete"
 msgstr ""
 
-#: components/partials/SongInfo.tsx:176
-#: components/partials/SongInfo.tsx:186
+#: components/partials/SongInfo.tsx:176 components/partials/SongInfo.tsx:186
 msgid "Delete song"
 msgstr "Song löschen"
 
@@ -140,8 +131,7 @@ msgstr "Favoriten"
 msgid "GitHub Project"
 msgstr "GitHub-Projekt"
 
-#: utils/pickAndImportDB.ts:16
-#: utils/pickAndImportDB.ts:28
+#: utils/pickAndImportDB.ts:16 utils/pickAndImportDB.ts:28
 #: utils/pickAndImportDB.ts:34
 msgid "Import database"
 msgstr "Datenbank importieren"
@@ -154,8 +144,7 @@ msgstr "Musikdatenbank importieren"
 msgid "Last songs"
 msgstr "Letzte Songs"
 
-#: app/albums/edit/[id].tsx:291
-#: app/artists/edit/[id].tsx:291
+#: app/albums/edit/[id].tsx:291 app/artists/edit/[id].tsx:291
 msgid "Merge"
 msgstr "Zusammenführen"
 
@@ -167,30 +156,24 @@ msgstr ""
 msgid "Merge artists"
 msgstr "Künstler zusammenführen"
 
-#: app/albums/edit/[id].tsx:268
-#: app/artists/edit/[id].tsx:268
+#: app/albums/edit/[id].tsx:268 app/artists/edit/[id].tsx:268
 msgid "Merge them"
 msgstr "Zusammenführen"
 
-#: app/albums/edit/[id].tsx:269
-#: app/artists/edit/[id].tsx:269
+#: app/albums/edit/[id].tsx:269 app/artists/edit/[id].tsx:269
 msgid "Merging..."
 msgstr "Wird zusammengeführt..."
 
-#: app/albums/edit/[id].tsx:82
-#: app/albums/new.tsx:76
-#: app/artists/edit/[id].tsx:82
-#: app/artists/new.tsx:76
+#: app/albums/edit/[id].tsx:82 app/albums/new.tsx:76
+#: app/artists/edit/[id].tsx:82 app/artists/new.tsx:76
 msgid "Name"
 msgstr "Name"
 
-#: app/albums/new.tsx:65
-#: app/albums/new.tsx:150
+#: app/albums/new.tsx:65 app/albums/new.tsx:150
 msgid "New album"
 msgstr ""
 
-#: app/artists/new.tsx:65
-#: app/artists/new.tsx:150
+#: app/artists/new.tsx:65 app/artists/new.tsx:150
 msgid "New artist"
 msgstr ""
 
@@ -210,10 +193,8 @@ msgstr ""
 msgid "Nombre del artista"
 msgstr "Name des Künstlers"
 
-#: app/albums/edit/[id].tsx:50
-#: app/albums/new.tsx:36
-#: app/artists/edit/[id].tsx:50
-#: app/artists/new.tsx:36
+#: app/albums/edit/[id].tsx:50 app/albums/new.tsx:36
+#: app/artists/edit/[id].tsx:50 app/artists/new.tsx:36
 #: app/song/edit/[id].tsx:40
 msgid "Not valid URL"
 msgstr "Ungültige URL"
@@ -242,18 +223,14 @@ msgstr ""
 msgid "Same artist?"
 msgstr "Gleicher Künstler?"
 
-#: app/albums/edit/[id].tsx:128
-#: app/albums/new.tsx:122
-#: app/artists/edit/[id].tsx:128
-#: app/artists/new.tsx:122
+#: app/albums/edit/[id].tsx:128 app/albums/new.tsx:122
+#: app/artists/edit/[id].tsx:128 app/artists/new.tsx:122
 #: app/song/edit/[id].tsx:193
 msgid "Save"
 msgstr "Speichern"
 
-#: app/albums/edit/[id].tsx:128
-#: app/albums/new.tsx:122
-#: app/artists/edit/[id].tsx:128
-#: app/artists/new.tsx:122
+#: app/albums/edit/[id].tsx:128 app/albums/new.tsx:122
+#: app/artists/edit/[id].tsx:128 app/artists/new.tsx:122
 #: app/song/edit/[id].tsx:193
 msgid "Saving..."
 msgstr "Speichern..."
@@ -262,8 +239,7 @@ msgstr "Speichern..."
 msgid "Search songs"
 msgstr "Songs suchen"
 
-#: components/ui/Select.tsx:54
-#: components/ui/Select.tsx:105
+#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
 msgid "Select an option"
 msgstr ""
 
@@ -271,8 +247,7 @@ msgstr ""
 msgid "Selection canceled"
 msgstr "Auswahl abgebrochen"
 
-#: components/partials/DrawerContent.tsx:53
-#: components/partials/Heading.tsx:41
+#: components/partials/DrawerContent.tsx:53 components/partials/Heading.tsx:41
 msgid "Settings"
 msgstr "Einstellungen"
 
@@ -284,8 +259,7 @@ msgstr ""
 msgid "Song update"
 msgstr ""
 
-#: app/albums/[id].tsx:88
-#: app/artists/[id].tsx:88
+#: app/albums/[id].tsx:88 app/artists/[id].tsx:88
 #: components/partials/Heading.tsx:35
 msgid "Songs"
 msgstr "Songs"
@@ -298,8 +272,7 @@ msgstr ""
 msgid "The artists have been merged successfully"
 msgstr "Die Künstler wurden erfolgreich zusammengeführt"
 
-#: app/artists/edit/[id].tsx:43
-#: app/artists/new.tsx:29
+#: app/artists/edit/[id].tsx:43 app/artists/new.tsx:29
 msgid "The name must have at least 2 characters"
 msgstr "Der Name muss mindestens 2 Zeichen haben"
 
@@ -307,42 +280,39 @@ msgstr "Der Name muss mindestens 2 Zeichen haben"
 msgid "The song has been updated correctly"
 msgstr ""
 
-#: app/albums/edit/[id].tsx:43
-#: app/albums/new.tsx:29
-#: app/song/edit/[id].tsx:33
+#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
 msgid "The title must have at least 2 characters"
 msgstr ""
 
 #: app/albums/edit/[id].tsx:237
-msgid "These albums share the same title because Android reads it from the ID3 tags, which you can edit in Lissn."
+msgid ""
+"These albums share the same title because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
 msgstr ""
 
 #: app/artists/edit/[id].tsx:237
-msgid "These artists share the same name because Android reads it from the ID3 tags, which you can edit in Lissn."
-msgstr "Diese Künstler teilen sich denselben Namen, weil Android ihn aus den ID3-Tags liest, die du in Lissn bearbeiten kannst."
+msgid ""
+"These artists share the same name because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
+msgstr ""
+"Diese Künstler teilen sich denselben Namen, weil Android ihn aus den ID3-"
+"Tags liest, die du in Lissn bearbeiten kannst."
 
-#: components/partials/SongInfo.tsx:97
-#~ msgid "Tile"
-#~ msgstr "Kachel"
-
-#: app/song/edit/[id].tsx:85
-#: components/partials/SongInfo.tsx:104
+#: app/song/edit/[id].tsx:85 components/partials/SongInfo.tsx:104
 msgid "Title"
 msgstr "Titel"
 
-#: app/albums/edit/[id].tsx:44
-#: app/albums/edit/[id].tsx:47
-#: app/albums/new.tsx:30
-#: app/albums/new.tsx:33
-#: app/artists/edit/[id].tsx:44
-#: app/artists/edit/[id].tsx:47
-#: app/artists/new.tsx:30
-#: app/artists/new.tsx:33
-#: app/song/edit/[id].tsx:34
-#: app/song/edit/[id].tsx:37
+#: app/albums/edit/[id].tsx:44 app/albums/edit/[id].tsx:47
+#: app/albums/new.tsx:30 app/albums/new.tsx:33 app/artists/edit/[id].tsx:44
+#: app/artists/edit/[id].tsx:47 app/artists/new.tsx:30 app/artists/new.tsx:33
+#: app/song/edit/[id].tsx:34 app/song/edit/[id].tsx:37
 msgid "Too long"
 msgstr "Zu lang"
 
 #: components/partials/DrawerContent.tsx:36
 msgid "Your music app"
 msgstr "Deine Musik-App"
+
+#: components/partials/SongInfo.tsx:97
+#~ msgid "Tile"
+#~ msgstr "Kachel"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -1,16 +1,16 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2025-08-14 00:43+0200\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"X-Generator: @lingui/cli\n"
-"Language: es\n"
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 00:43+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
 "Plural-Forms: \n"
 
 #: components/partials/SongInfo.tsx:151
@@ -21,8 +21,7 @@ msgstr "Añadir a favoritos"
 msgid "Add to playlist"
 msgstr "Añadir a la lista de reproducción"
 
-#: app/song/edit/[id].tsx:162
-#: components/partials/SongInfo.tsx:114
+#: app/song/edit/[id].tsx:162 components/partials/SongInfo.tsx:114
 msgid "Album"
 msgstr "Álbum"
 
@@ -46,8 +45,7 @@ msgstr ""
 msgid "Are you sure you want to delete the song?"
 msgstr ""
 
-#: app/song/edit/[id].tsx:131
-#: components/partials/SongInfo.tsx:108
+#: app/song/edit/[id].tsx:131 components/partials/SongInfo.tsx:108
 msgid "Artist"
 msgstr "Artista"
 
@@ -67,22 +65,16 @@ msgstr "Artistas"
 msgid "Artists merged"
 msgstr "Artistas fusionados"
 
-#: app/albums/edit/[id].tsx:103
-#: app/albums/new.tsx:97
-#: app/artists/edit/[id].tsx:103
-#: app/artists/new.tsx:97
+#: app/albums/edit/[id].tsx:103 app/albums/new.tsx:97
+#: app/artists/edit/[id].tsx:103 app/artists/new.tsx:97
 #: app/song/edit/[id].tsx:106
 msgid "Artwork URL"
 msgstr "URL de la portada"
 
-#: app/albums/edit/[id].tsx:225
-#: app/albums/edit/[id].tsx:301
-#: app/albums/new.tsx:166
-#: app/artists/edit/[id].tsx:225
-#: app/artists/edit/[id].tsx:301
-#: app/artists/new.tsx:166
-#: app/song/edit/[id].tsx:262
-#: components/partials/SongInfo.tsx:216
+#: app/albums/edit/[id].tsx:225 app/albums/edit/[id].tsx:301
+#: app/albums/new.tsx:166 app/artists/edit/[id].tsx:225
+#: app/artists/edit/[id].tsx:301 app/artists/new.tsx:166
+#: app/song/edit/[id].tsx:262 components/partials/SongInfo.tsx:216
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -102,8 +94,7 @@ msgstr "Base de datos importada correctamente"
 msgid "Delete"
 msgstr ""
 
-#: components/partials/SongInfo.tsx:176
-#: components/partials/SongInfo.tsx:186
+#: components/partials/SongInfo.tsx:176 components/partials/SongInfo.tsx:186
 msgid "Delete song"
 msgstr "Eliminar canción"
 
@@ -140,8 +131,7 @@ msgstr "Favoritos"
 msgid "GitHub Project"
 msgstr "Proyecto en GitHub"
 
-#: utils/pickAndImportDB.ts:16
-#: utils/pickAndImportDB.ts:28
+#: utils/pickAndImportDB.ts:16 utils/pickAndImportDB.ts:28
 #: utils/pickAndImportDB.ts:34
 msgid "Import database"
 msgstr "Importar base de datos"
@@ -154,8 +144,7 @@ msgstr "Importar base de datos musical"
 msgid "Last songs"
 msgstr "Últimas canciones"
 
-#: app/albums/edit/[id].tsx:291
-#: app/artists/edit/[id].tsx:291
+#: app/albums/edit/[id].tsx:291 app/artists/edit/[id].tsx:291
 msgid "Merge"
 msgstr "Fusionar"
 
@@ -167,30 +156,24 @@ msgstr ""
 msgid "Merge artists"
 msgstr "Fusionar artistas"
 
-#: app/albums/edit/[id].tsx:268
-#: app/artists/edit/[id].tsx:268
+#: app/albums/edit/[id].tsx:268 app/artists/edit/[id].tsx:268
 msgid "Merge them"
 msgstr "Fusionarlos"
 
-#: app/albums/edit/[id].tsx:269
-#: app/artists/edit/[id].tsx:269
+#: app/albums/edit/[id].tsx:269 app/artists/edit/[id].tsx:269
 msgid "Merging..."
 msgstr "Fusionando..."
 
-#: app/albums/edit/[id].tsx:82
-#: app/albums/new.tsx:76
-#: app/artists/edit/[id].tsx:82
-#: app/artists/new.tsx:76
+#: app/albums/edit/[id].tsx:82 app/albums/new.tsx:76
+#: app/artists/edit/[id].tsx:82 app/artists/new.tsx:76
 msgid "Name"
 msgstr "Nombre"
 
-#: app/albums/new.tsx:65
-#: app/albums/new.tsx:150
+#: app/albums/new.tsx:65 app/albums/new.tsx:150
 msgid "New album"
 msgstr ""
 
-#: app/artists/new.tsx:65
-#: app/artists/new.tsx:150
+#: app/artists/new.tsx:65 app/artists/new.tsx:150
 msgid "New artist"
 msgstr ""
 
@@ -210,10 +193,8 @@ msgstr ""
 msgid "Nombre del artista"
 msgstr "Nombre del artista"
 
-#: app/albums/edit/[id].tsx:50
-#: app/albums/new.tsx:36
-#: app/artists/edit/[id].tsx:50
-#: app/artists/new.tsx:36
+#: app/albums/edit/[id].tsx:50 app/albums/new.tsx:36
+#: app/artists/edit/[id].tsx:50 app/artists/new.tsx:36
 #: app/song/edit/[id].tsx:40
 msgid "Not valid URL"
 msgstr "URL no válida"
@@ -242,18 +223,14 @@ msgstr ""
 msgid "Same artist?"
 msgstr "¿El mismo artista?"
 
-#: app/albums/edit/[id].tsx:128
-#: app/albums/new.tsx:122
-#: app/artists/edit/[id].tsx:128
-#: app/artists/new.tsx:122
+#: app/albums/edit/[id].tsx:128 app/albums/new.tsx:122
+#: app/artists/edit/[id].tsx:128 app/artists/new.tsx:122
 #: app/song/edit/[id].tsx:193
 msgid "Save"
 msgstr "Guardar"
 
-#: app/albums/edit/[id].tsx:128
-#: app/albums/new.tsx:122
-#: app/artists/edit/[id].tsx:128
-#: app/artists/new.tsx:122
+#: app/albums/edit/[id].tsx:128 app/albums/new.tsx:122
+#: app/artists/edit/[id].tsx:128 app/artists/new.tsx:122
 #: app/song/edit/[id].tsx:193
 msgid "Saving..."
 msgstr "Guardando..."
@@ -262,8 +239,7 @@ msgstr "Guardando..."
 msgid "Search songs"
 msgstr "Buscar canciones"
 
-#: components/ui/Select.tsx:54
-#: components/ui/Select.tsx:105
+#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
 msgid "Select an option"
 msgstr ""
 
@@ -271,8 +247,7 @@ msgstr ""
 msgid "Selection canceled"
 msgstr "Selección cancelada"
 
-#: components/partials/DrawerContent.tsx:53
-#: components/partials/Heading.tsx:41
+#: components/partials/DrawerContent.tsx:53 components/partials/Heading.tsx:41
 msgid "Settings"
 msgstr "Configuración"
 
@@ -284,8 +259,7 @@ msgstr ""
 msgid "Song update"
 msgstr ""
 
-#: app/albums/[id].tsx:88
-#: app/artists/[id].tsx:88
+#: app/albums/[id].tsx:88 app/artists/[id].tsx:88
 #: components/partials/Heading.tsx:35
 msgid "Songs"
 msgstr "Canciones"
@@ -298,8 +272,7 @@ msgstr ""
 msgid "The artists have been merged successfully"
 msgstr "Los artistas se han fusionado correctamente"
 
-#: app/artists/edit/[id].tsx:43
-#: app/artists/new.tsx:29
+#: app/artists/edit/[id].tsx:43 app/artists/new.tsx:29
 msgid "The name must have at least 2 characters"
 msgstr "El nombre debe tener al menos 2 caracteres"
 
@@ -307,42 +280,39 @@ msgstr "El nombre debe tener al menos 2 caracteres"
 msgid "The song has been updated correctly"
 msgstr ""
 
-#: app/albums/edit/[id].tsx:43
-#: app/albums/new.tsx:29
-#: app/song/edit/[id].tsx:33
+#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
 msgid "The title must have at least 2 characters"
 msgstr ""
 
 #: app/albums/edit/[id].tsx:237
-msgid "These albums share the same title because Android reads it from the ID3 tags, which you can edit in Lissn."
+msgid ""
+"These albums share the same title because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
 msgstr ""
 
 #: app/artists/edit/[id].tsx:237
-msgid "These artists share the same name because Android reads it from the ID3 tags, which you can edit in Lissn."
-msgstr "Estos artistas comparten el mismo nombre porque Android lo lee de las etiquetas ID3, que puedes editar en Lissn."
+msgid ""
+"These artists share the same name because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
+msgstr ""
+"Estos artistas comparten el mismo nombre porque Android lo lee de las "
+"etiquetas ID3, que puedes editar en Lissn."
 
-#: components/partials/SongInfo.tsx:97
-#~ msgid "Tile"
-#~ msgstr "Miniatura"
-
-#: app/song/edit/[id].tsx:85
-#: components/partials/SongInfo.tsx:104
+#: app/song/edit/[id].tsx:85 components/partials/SongInfo.tsx:104
 msgid "Title"
 msgstr "Título"
 
-#: app/albums/edit/[id].tsx:44
-#: app/albums/edit/[id].tsx:47
-#: app/albums/new.tsx:30
-#: app/albums/new.tsx:33
-#: app/artists/edit/[id].tsx:44
-#: app/artists/edit/[id].tsx:47
-#: app/artists/new.tsx:30
-#: app/artists/new.tsx:33
-#: app/song/edit/[id].tsx:34
-#: app/song/edit/[id].tsx:37
+#: app/albums/edit/[id].tsx:44 app/albums/edit/[id].tsx:47
+#: app/albums/new.tsx:30 app/albums/new.tsx:33 app/artists/edit/[id].tsx:44
+#: app/artists/edit/[id].tsx:47 app/artists/new.tsx:30 app/artists/new.tsx:33
+#: app/song/edit/[id].tsx:34 app/song/edit/[id].tsx:37
 msgid "Too long"
 msgstr "Demasiado largo"
 
 #: components/partials/DrawerContent.tsx:36
 msgid "Your music app"
 msgstr "Tu aplicación de música"
+
+#: components/partials/SongInfo.tsx:97
+#~ msgid "Tile"
+#~ msgstr "Miniatura"

--- a/locales/fr/messages.po
+++ b/locales/fr/messages.po
@@ -1,16 +1,16 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2025-08-14 00:43+0200\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"X-Generator: @lingui/cli\n"
-"Language: fr\n"
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 00:43+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
 "Plural-Forms: \n"
 
 #: components/partials/SongInfo.tsx:151
@@ -21,8 +21,7 @@ msgstr "Ajouter aux favoris"
 msgid "Add to playlist"
 msgstr "Ajouter à la playlist"
 
-#: app/song/edit/[id].tsx:162
-#: components/partials/SongInfo.tsx:114
+#: app/song/edit/[id].tsx:162 components/partials/SongInfo.tsx:114
 msgid "Album"
 msgstr "Album"
 
@@ -46,8 +45,7 @@ msgstr ""
 msgid "Are you sure you want to delete the song?"
 msgstr ""
 
-#: app/song/edit/[id].tsx:131
-#: components/partials/SongInfo.tsx:108
+#: app/song/edit/[id].tsx:131 components/partials/SongInfo.tsx:108
 msgid "Artist"
 msgstr "Artiste"
 
@@ -67,22 +65,16 @@ msgstr "Artistes"
 msgid "Artists merged"
 msgstr "Artistes fusionnés"
 
-#: app/albums/edit/[id].tsx:103
-#: app/albums/new.tsx:97
-#: app/artists/edit/[id].tsx:103
-#: app/artists/new.tsx:97
+#: app/albums/edit/[id].tsx:103 app/albums/new.tsx:97
+#: app/artists/edit/[id].tsx:103 app/artists/new.tsx:97
 #: app/song/edit/[id].tsx:106
 msgid "Artwork URL"
 msgstr "URL de l'illustration"
 
-#: app/albums/edit/[id].tsx:225
-#: app/albums/edit/[id].tsx:301
-#: app/albums/new.tsx:166
-#: app/artists/edit/[id].tsx:225
-#: app/artists/edit/[id].tsx:301
-#: app/artists/new.tsx:166
-#: app/song/edit/[id].tsx:262
-#: components/partials/SongInfo.tsx:216
+#: app/albums/edit/[id].tsx:225 app/albums/edit/[id].tsx:301
+#: app/albums/new.tsx:166 app/artists/edit/[id].tsx:225
+#: app/artists/edit/[id].tsx:301 app/artists/new.tsx:166
+#: app/song/edit/[id].tsx:262 components/partials/SongInfo.tsx:216
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -102,8 +94,7 @@ msgstr "Base de données importée avec succès"
 msgid "Delete"
 msgstr ""
 
-#: components/partials/SongInfo.tsx:176
-#: components/partials/SongInfo.tsx:186
+#: components/partials/SongInfo.tsx:176 components/partials/SongInfo.tsx:186
 msgid "Delete song"
 msgstr "Supprimer la chanson"
 
@@ -140,8 +131,7 @@ msgstr "Favoris"
 msgid "GitHub Project"
 msgstr "Projet GitHub"
 
-#: utils/pickAndImportDB.ts:16
-#: utils/pickAndImportDB.ts:28
+#: utils/pickAndImportDB.ts:16 utils/pickAndImportDB.ts:28
 #: utils/pickAndImportDB.ts:34
 msgid "Import database"
 msgstr "Importer la base de données"
@@ -154,8 +144,7 @@ msgstr "Importer la base de données musicale"
 msgid "Last songs"
 msgstr "Dernières chansons"
 
-#: app/albums/edit/[id].tsx:291
-#: app/artists/edit/[id].tsx:291
+#: app/albums/edit/[id].tsx:291 app/artists/edit/[id].tsx:291
 msgid "Merge"
 msgstr "Fusionner"
 
@@ -167,30 +156,24 @@ msgstr ""
 msgid "Merge artists"
 msgstr "Fusionner les artistes"
 
-#: app/albums/edit/[id].tsx:268
-#: app/artists/edit/[id].tsx:268
+#: app/albums/edit/[id].tsx:268 app/artists/edit/[id].tsx:268
 msgid "Merge them"
 msgstr "Les fusionner"
 
-#: app/albums/edit/[id].tsx:269
-#: app/artists/edit/[id].tsx:269
+#: app/albums/edit/[id].tsx:269 app/artists/edit/[id].tsx:269
 msgid "Merging..."
 msgstr "Fusion en cours..."
 
-#: app/albums/edit/[id].tsx:82
-#: app/albums/new.tsx:76
-#: app/artists/edit/[id].tsx:82
-#: app/artists/new.tsx:76
+#: app/albums/edit/[id].tsx:82 app/albums/new.tsx:76
+#: app/artists/edit/[id].tsx:82 app/artists/new.tsx:76
 msgid "Name"
 msgstr "Nom"
 
-#: app/albums/new.tsx:65
-#: app/albums/new.tsx:150
+#: app/albums/new.tsx:65 app/albums/new.tsx:150
 msgid "New album"
 msgstr ""
 
-#: app/artists/new.tsx:65
-#: app/artists/new.tsx:150
+#: app/artists/new.tsx:65 app/artists/new.tsx:150
 msgid "New artist"
 msgstr ""
 
@@ -210,10 +193,8 @@ msgstr ""
 msgid "Nombre del artista"
 msgstr "Nom de l'artiste"
 
-#: app/albums/edit/[id].tsx:50
-#: app/albums/new.tsx:36
-#: app/artists/edit/[id].tsx:50
-#: app/artists/new.tsx:36
+#: app/albums/edit/[id].tsx:50 app/albums/new.tsx:36
+#: app/artists/edit/[id].tsx:50 app/artists/new.tsx:36
 #: app/song/edit/[id].tsx:40
 msgid "Not valid URL"
 msgstr "URL non valide"
@@ -242,18 +223,14 @@ msgstr ""
 msgid "Same artist?"
 msgstr "Même artiste ?"
 
-#: app/albums/edit/[id].tsx:128
-#: app/albums/new.tsx:122
-#: app/artists/edit/[id].tsx:128
-#: app/artists/new.tsx:122
+#: app/albums/edit/[id].tsx:128 app/albums/new.tsx:122
+#: app/artists/edit/[id].tsx:128 app/artists/new.tsx:122
 #: app/song/edit/[id].tsx:193
 msgid "Save"
 msgstr "Enregistrer"
 
-#: app/albums/edit/[id].tsx:128
-#: app/albums/new.tsx:122
-#: app/artists/edit/[id].tsx:128
-#: app/artists/new.tsx:122
+#: app/albums/edit/[id].tsx:128 app/albums/new.tsx:122
+#: app/artists/edit/[id].tsx:128 app/artists/new.tsx:122
 #: app/song/edit/[id].tsx:193
 msgid "Saving..."
 msgstr "Enregistrement..."
@@ -262,8 +239,7 @@ msgstr "Enregistrement..."
 msgid "Search songs"
 msgstr "Rechercher des chansons"
 
-#: components/ui/Select.tsx:54
-#: components/ui/Select.tsx:105
+#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
 msgid "Select an option"
 msgstr ""
 
@@ -271,8 +247,7 @@ msgstr ""
 msgid "Selection canceled"
 msgstr "Sélection annulée"
 
-#: components/partials/DrawerContent.tsx:53
-#: components/partials/Heading.tsx:41
+#: components/partials/DrawerContent.tsx:53 components/partials/Heading.tsx:41
 msgid "Settings"
 msgstr "Paramètres"
 
@@ -284,8 +259,7 @@ msgstr ""
 msgid "Song update"
 msgstr ""
 
-#: app/albums/[id].tsx:88
-#: app/artists/[id].tsx:88
+#: app/albums/[id].tsx:88 app/artists/[id].tsx:88
 #: components/partials/Heading.tsx:35
 msgid "Songs"
 msgstr "Chansons"
@@ -298,8 +272,7 @@ msgstr ""
 msgid "The artists have been merged successfully"
 msgstr "Les artistes ont été fusionnés avec succès"
 
-#: app/artists/edit/[id].tsx:43
-#: app/artists/new.tsx:29
+#: app/artists/edit/[id].tsx:43 app/artists/new.tsx:29
 msgid "The name must have at least 2 characters"
 msgstr "Le nom doit comporter au moins 2 caractères"
 
@@ -307,42 +280,39 @@ msgstr "Le nom doit comporter au moins 2 caractères"
 msgid "The song has been updated correctly"
 msgstr ""
 
-#: app/albums/edit/[id].tsx:43
-#: app/albums/new.tsx:29
-#: app/song/edit/[id].tsx:33
+#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
 msgid "The title must have at least 2 characters"
 msgstr ""
 
 #: app/albums/edit/[id].tsx:237
-msgid "These albums share the same title because Android reads it from the ID3 tags, which you can edit in Lissn."
+msgid ""
+"These albums share the same title because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
 msgstr ""
 
 #: app/artists/edit/[id].tsx:237
-msgid "These artists share the same name because Android reads it from the ID3 tags, which you can edit in Lissn."
-msgstr "Ces artistes partagent le même nom parce qu'Android le lit à partir des balises ID3, que vous pouvez modifier dans Lissn."
+msgid ""
+"These artists share the same name because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
+msgstr ""
+"Ces artistes partagent le même nom parce qu'Android le lit à partir des "
+"balises ID3, que vous pouvez modifier dans Lissn."
 
-#: components/partials/SongInfo.tsx:97
-#~ msgid "Tile"
-#~ msgstr "Vignette"
-
-#: app/song/edit/[id].tsx:85
-#: components/partials/SongInfo.tsx:104
+#: app/song/edit/[id].tsx:85 components/partials/SongInfo.tsx:104
 msgid "Title"
 msgstr "Titre"
 
-#: app/albums/edit/[id].tsx:44
-#: app/albums/edit/[id].tsx:47
-#: app/albums/new.tsx:30
-#: app/albums/new.tsx:33
-#: app/artists/edit/[id].tsx:44
-#: app/artists/edit/[id].tsx:47
-#: app/artists/new.tsx:30
-#: app/artists/new.tsx:33
-#: app/song/edit/[id].tsx:34
-#: app/song/edit/[id].tsx:37
+#: app/albums/edit/[id].tsx:44 app/albums/edit/[id].tsx:47
+#: app/albums/new.tsx:30 app/albums/new.tsx:33 app/artists/edit/[id].tsx:44
+#: app/artists/edit/[id].tsx:47 app/artists/new.tsx:30 app/artists/new.tsx:33
+#: app/song/edit/[id].tsx:34 app/song/edit/[id].tsx:37
 msgid "Too long"
 msgstr "Trop long"
 
 #: components/partials/DrawerContent.tsx:36
 msgid "Your music app"
 msgstr "Votre application musicale"
+
+#: components/partials/SongInfo.tsx:97
+#~ msgid "Tile"
+#~ msgstr "Vignette"

--- a/locales/hi/messages.po
+++ b/locales/hi/messages.po
@@ -1,16 +1,16 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2025-08-14 00:43+0200\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"X-Generator: @lingui/cli\n"
-"Language: hi\n"
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 00:43+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: hi\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
 "Plural-Forms: \n"
 
 #: components/partials/SongInfo.tsx:151
@@ -21,8 +21,7 @@ msgstr "पसंदीदा में जोड़ें"
 msgid "Add to playlist"
 msgstr "प्लेलिस्ट में जोड़ें"
 
-#: app/song/edit/[id].tsx:162
-#: components/partials/SongInfo.tsx:114
+#: app/song/edit/[id].tsx:162 components/partials/SongInfo.tsx:114
 msgid "Album"
 msgstr "एल्बम"
 
@@ -46,8 +45,7 @@ msgstr ""
 msgid "Are you sure you want to delete the song?"
 msgstr ""
 
-#: app/song/edit/[id].tsx:131
-#: components/partials/SongInfo.tsx:108
+#: app/song/edit/[id].tsx:131 components/partials/SongInfo.tsx:108
 msgid "Artist"
 msgstr "कलाकार"
 
@@ -67,22 +65,16 @@ msgstr "कलाकार"
 msgid "Artists merged"
 msgstr "कलाकारों को जोड़ा गया"
 
-#: app/albums/edit/[id].tsx:103
-#: app/albums/new.tsx:97
-#: app/artists/edit/[id].tsx:103
-#: app/artists/new.tsx:97
+#: app/albums/edit/[id].tsx:103 app/albums/new.tsx:97
+#: app/artists/edit/[id].tsx:103 app/artists/new.tsx:97
 #: app/song/edit/[id].tsx:106
 msgid "Artwork URL"
 msgstr "कलाकृति URL"
 
-#: app/albums/edit/[id].tsx:225
-#: app/albums/edit/[id].tsx:301
-#: app/albums/new.tsx:166
-#: app/artists/edit/[id].tsx:225
-#: app/artists/edit/[id].tsx:301
-#: app/artists/new.tsx:166
-#: app/song/edit/[id].tsx:262
-#: components/partials/SongInfo.tsx:216
+#: app/albums/edit/[id].tsx:225 app/albums/edit/[id].tsx:301
+#: app/albums/new.tsx:166 app/artists/edit/[id].tsx:225
+#: app/artists/edit/[id].tsx:301 app/artists/new.tsx:166
+#: app/song/edit/[id].tsx:262 components/partials/SongInfo.tsx:216
 msgid "Cancel"
 msgstr "रद्द करें"
 
@@ -102,8 +94,7 @@ msgstr "डेटाबेस सफलतापूर्वक आयात क
 msgid "Delete"
 msgstr ""
 
-#: components/partials/SongInfo.tsx:176
-#: components/partials/SongInfo.tsx:186
+#: components/partials/SongInfo.tsx:176 components/partials/SongInfo.tsx:186
 msgid "Delete song"
 msgstr "गीत हटाएं"
 
@@ -140,8 +131,7 @@ msgstr "पसंदीदा"
 msgid "GitHub Project"
 msgstr "GitHub परियोजना"
 
-#: utils/pickAndImportDB.ts:16
-#: utils/pickAndImportDB.ts:28
+#: utils/pickAndImportDB.ts:16 utils/pickAndImportDB.ts:28
 #: utils/pickAndImportDB.ts:34
 msgid "Import database"
 msgstr "डेटाबेस आयात करें"
@@ -154,8 +144,7 @@ msgstr "संगीत डेटाबेस आयात करें"
 msgid "Last songs"
 msgstr "आखिरी गीत"
 
-#: app/albums/edit/[id].tsx:291
-#: app/artists/edit/[id].tsx:291
+#: app/albums/edit/[id].tsx:291 app/artists/edit/[id].tsx:291
 msgid "Merge"
 msgstr "मिलाएँ"
 
@@ -167,30 +156,24 @@ msgstr ""
 msgid "Merge artists"
 msgstr "कलाकारों को मिलाएँ"
 
-#: app/albums/edit/[id].tsx:268
-#: app/artists/edit/[id].tsx:268
+#: app/albums/edit/[id].tsx:268 app/artists/edit/[id].tsx:268
 msgid "Merge them"
 msgstr "उन्हें मिलाएँ"
 
-#: app/albums/edit/[id].tsx:269
-#: app/artists/edit/[id].tsx:269
+#: app/albums/edit/[id].tsx:269 app/artists/edit/[id].tsx:269
 msgid "Merging..."
 msgstr "मिला रहे हैं..."
 
-#: app/albums/edit/[id].tsx:82
-#: app/albums/new.tsx:76
-#: app/artists/edit/[id].tsx:82
-#: app/artists/new.tsx:76
+#: app/albums/edit/[id].tsx:82 app/albums/new.tsx:76
+#: app/artists/edit/[id].tsx:82 app/artists/new.tsx:76
 msgid "Name"
 msgstr "नाम"
 
-#: app/albums/new.tsx:65
-#: app/albums/new.tsx:150
+#: app/albums/new.tsx:65 app/albums/new.tsx:150
 msgid "New album"
 msgstr ""
 
-#: app/artists/new.tsx:65
-#: app/artists/new.tsx:150
+#: app/artists/new.tsx:65 app/artists/new.tsx:150
 msgid "New artist"
 msgstr ""
 
@@ -210,10 +193,8 @@ msgstr ""
 msgid "Nombre del artista"
 msgstr "कलाकार का नाम"
 
-#: app/albums/edit/[id].tsx:50
-#: app/albums/new.tsx:36
-#: app/artists/edit/[id].tsx:50
-#: app/artists/new.tsx:36
+#: app/albums/edit/[id].tsx:50 app/albums/new.tsx:36
+#: app/artists/edit/[id].tsx:50 app/artists/new.tsx:36
 #: app/song/edit/[id].tsx:40
 msgid "Not valid URL"
 msgstr "अमान्य URL"
@@ -242,18 +223,14 @@ msgstr ""
 msgid "Same artist?"
 msgstr "क्या वही कलाकार है?"
 
-#: app/albums/edit/[id].tsx:128
-#: app/albums/new.tsx:122
-#: app/artists/edit/[id].tsx:128
-#: app/artists/new.tsx:122
+#: app/albums/edit/[id].tsx:128 app/albums/new.tsx:122
+#: app/artists/edit/[id].tsx:128 app/artists/new.tsx:122
 #: app/song/edit/[id].tsx:193
 msgid "Save"
 msgstr "सहेजें"
 
-#: app/albums/edit/[id].tsx:128
-#: app/albums/new.tsx:122
-#: app/artists/edit/[id].tsx:128
-#: app/artists/new.tsx:122
+#: app/albums/edit/[id].tsx:128 app/albums/new.tsx:122
+#: app/artists/edit/[id].tsx:128 app/artists/new.tsx:122
 #: app/song/edit/[id].tsx:193
 msgid "Saving..."
 msgstr "सहेजा जा रहा है..."
@@ -262,8 +239,7 @@ msgstr "सहेजा जा रहा है..."
 msgid "Search songs"
 msgstr "गीत खोजें"
 
-#: components/ui/Select.tsx:54
-#: components/ui/Select.tsx:105
+#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
 msgid "Select an option"
 msgstr ""
 
@@ -271,8 +247,7 @@ msgstr ""
 msgid "Selection canceled"
 msgstr "चयन रद्द किया गया"
 
-#: components/partials/DrawerContent.tsx:53
-#: components/partials/Heading.tsx:41
+#: components/partials/DrawerContent.tsx:53 components/partials/Heading.tsx:41
 msgid "Settings"
 msgstr "सेटिंग्स"
 
@@ -284,8 +259,7 @@ msgstr ""
 msgid "Song update"
 msgstr ""
 
-#: app/albums/[id].tsx:88
-#: app/artists/[id].tsx:88
+#: app/albums/[id].tsx:88 app/artists/[id].tsx:88
 #: components/partials/Heading.tsx:35
 msgid "Songs"
 msgstr "गीत"
@@ -298,8 +272,7 @@ msgstr ""
 msgid "The artists have been merged successfully"
 msgstr "कलाकारों को सफलतापूर्वक मिला दिया गया है"
 
-#: app/artists/edit/[id].tsx:43
-#: app/artists/new.tsx:29
+#: app/artists/edit/[id].tsx:43 app/artists/new.tsx:29
 msgid "The name must have at least 2 characters"
 msgstr "नाम में कम से कम 2 अक्षर होने चाहिए"
 
@@ -307,42 +280,39 @@ msgstr "नाम में कम से कम 2 अक्षर होने 
 msgid "The song has been updated correctly"
 msgstr ""
 
-#: app/albums/edit/[id].tsx:43
-#: app/albums/new.tsx:29
-#: app/song/edit/[id].tsx:33
+#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
 msgid "The title must have at least 2 characters"
 msgstr ""
 
 #: app/albums/edit/[id].tsx:237
-msgid "These albums share the same title because Android reads it from the ID3 tags, which you can edit in Lissn."
+msgid ""
+"These albums share the same title because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
 msgstr ""
 
 #: app/artists/edit/[id].tsx:237
-msgid "These artists share the same name because Android reads it from the ID3 tags, which you can edit in Lissn."
-msgstr "इन कलाकारों का नाम समान है क्योंकि एंड्रॉइड इसे ID3 टैग्स से पढ़ता है, जिन्हें आप Lissn में संपादित कर सकते हैं."
+msgid ""
+"These artists share the same name because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
+msgstr ""
+"इन कलाकारों का नाम समान है क्योंकि एंड्रॉइड इसे ID3 टैग्स से पढ़ता है, जिन्हें आप Lissn में "
+"संपादित कर सकते हैं."
 
-#: components/partials/SongInfo.tsx:97
-#~ msgid "Tile"
-#~ msgstr "टाइल"
-
-#: app/song/edit/[id].tsx:85
-#: components/partials/SongInfo.tsx:104
+#: app/song/edit/[id].tsx:85 components/partials/SongInfo.tsx:104
 msgid "Title"
 msgstr "शीर्षक"
 
-#: app/albums/edit/[id].tsx:44
-#: app/albums/edit/[id].tsx:47
-#: app/albums/new.tsx:30
-#: app/albums/new.tsx:33
-#: app/artists/edit/[id].tsx:44
-#: app/artists/edit/[id].tsx:47
-#: app/artists/new.tsx:30
-#: app/artists/new.tsx:33
-#: app/song/edit/[id].tsx:34
-#: app/song/edit/[id].tsx:37
+#: app/albums/edit/[id].tsx:44 app/albums/edit/[id].tsx:47
+#: app/albums/new.tsx:30 app/albums/new.tsx:33 app/artists/edit/[id].tsx:44
+#: app/artists/edit/[id].tsx:47 app/artists/new.tsx:30 app/artists/new.tsx:33
+#: app/song/edit/[id].tsx:34 app/song/edit/[id].tsx:37
 msgid "Too long"
 msgstr "बहुत लंबा"
 
 #: components/partials/DrawerContent.tsx:36
 msgid "Your music app"
 msgstr "आपका संगीत ऐप"
+
+#: components/partials/SongInfo.tsx:97
+#~ msgid "Tile"
+#~ msgstr "टाइल"

--- a/locales/it/messages.po
+++ b/locales/it/messages.po
@@ -1,16 +1,16 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2025-08-14 00:43+0200\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"X-Generator: @lingui/cli\n"
-"Language: it\n"
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 00:43+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
 "Plural-Forms: \n"
 
 #: components/partials/SongInfo.tsx:151
@@ -21,8 +21,7 @@ msgstr "Aggiungi ai preferiti"
 msgid "Add to playlist"
 msgstr "Aggiungi alla playlist"
 
-#: app/song/edit/[id].tsx:162
-#: components/partials/SongInfo.tsx:114
+#: app/song/edit/[id].tsx:162 components/partials/SongInfo.tsx:114
 msgid "Album"
 msgstr "Album"
 
@@ -46,8 +45,7 @@ msgstr ""
 msgid "Are you sure you want to delete the song?"
 msgstr ""
 
-#: app/song/edit/[id].tsx:131
-#: components/partials/SongInfo.tsx:108
+#: app/song/edit/[id].tsx:131 components/partials/SongInfo.tsx:108
 msgid "Artist"
 msgstr "Artista"
 
@@ -67,22 +65,16 @@ msgstr "Artisti"
 msgid "Artists merged"
 msgstr "Artisti uniti"
 
-#: app/albums/edit/[id].tsx:103
-#: app/albums/new.tsx:97
-#: app/artists/edit/[id].tsx:103
-#: app/artists/new.tsx:97
+#: app/albums/edit/[id].tsx:103 app/albums/new.tsx:97
+#: app/artists/edit/[id].tsx:103 app/artists/new.tsx:97
 #: app/song/edit/[id].tsx:106
 msgid "Artwork URL"
 msgstr "URL della copertina"
 
-#: app/albums/edit/[id].tsx:225
-#: app/albums/edit/[id].tsx:301
-#: app/albums/new.tsx:166
-#: app/artists/edit/[id].tsx:225
-#: app/artists/edit/[id].tsx:301
-#: app/artists/new.tsx:166
-#: app/song/edit/[id].tsx:262
-#: components/partials/SongInfo.tsx:216
+#: app/albums/edit/[id].tsx:225 app/albums/edit/[id].tsx:301
+#: app/albums/new.tsx:166 app/artists/edit/[id].tsx:225
+#: app/artists/edit/[id].tsx:301 app/artists/new.tsx:166
+#: app/song/edit/[id].tsx:262 components/partials/SongInfo.tsx:216
 msgid "Cancel"
 msgstr "Annulla"
 
@@ -102,8 +94,7 @@ msgstr "Database importato con successo"
 msgid "Delete"
 msgstr ""
 
-#: components/partials/SongInfo.tsx:176
-#: components/partials/SongInfo.tsx:186
+#: components/partials/SongInfo.tsx:176 components/partials/SongInfo.tsx:186
 msgid "Delete song"
 msgstr "Elimina canzone"
 
@@ -140,8 +131,7 @@ msgstr "Preferiti"
 msgid "GitHub Project"
 msgstr "Progetto GitHub"
 
-#: utils/pickAndImportDB.ts:16
-#: utils/pickAndImportDB.ts:28
+#: utils/pickAndImportDB.ts:16 utils/pickAndImportDB.ts:28
 #: utils/pickAndImportDB.ts:34
 msgid "Import database"
 msgstr "Importa database"
@@ -154,8 +144,7 @@ msgstr "Importa database musicale"
 msgid "Last songs"
 msgstr "Ultime canzoni"
 
-#: app/albums/edit/[id].tsx:291
-#: app/artists/edit/[id].tsx:291
+#: app/albums/edit/[id].tsx:291 app/artists/edit/[id].tsx:291
 msgid "Merge"
 msgstr "Unisci"
 
@@ -167,30 +156,24 @@ msgstr ""
 msgid "Merge artists"
 msgstr "Unisci artisti"
 
-#: app/albums/edit/[id].tsx:268
-#: app/artists/edit/[id].tsx:268
+#: app/albums/edit/[id].tsx:268 app/artists/edit/[id].tsx:268
 msgid "Merge them"
 msgstr "Uniscili"
 
-#: app/albums/edit/[id].tsx:269
-#: app/artists/edit/[id].tsx:269
+#: app/albums/edit/[id].tsx:269 app/artists/edit/[id].tsx:269
 msgid "Merging..."
 msgstr "Unione in corso..."
 
-#: app/albums/edit/[id].tsx:82
-#: app/albums/new.tsx:76
-#: app/artists/edit/[id].tsx:82
-#: app/artists/new.tsx:76
+#: app/albums/edit/[id].tsx:82 app/albums/new.tsx:76
+#: app/artists/edit/[id].tsx:82 app/artists/new.tsx:76
 msgid "Name"
 msgstr "Nome"
 
-#: app/albums/new.tsx:65
-#: app/albums/new.tsx:150
+#: app/albums/new.tsx:65 app/albums/new.tsx:150
 msgid "New album"
 msgstr ""
 
-#: app/artists/new.tsx:65
-#: app/artists/new.tsx:150
+#: app/artists/new.tsx:65 app/artists/new.tsx:150
 msgid "New artist"
 msgstr ""
 
@@ -210,10 +193,8 @@ msgstr ""
 msgid "Nombre del artista"
 msgstr "Nome dell'artista"
 
-#: app/albums/edit/[id].tsx:50
-#: app/albums/new.tsx:36
-#: app/artists/edit/[id].tsx:50
-#: app/artists/new.tsx:36
+#: app/albums/edit/[id].tsx:50 app/albums/new.tsx:36
+#: app/artists/edit/[id].tsx:50 app/artists/new.tsx:36
 #: app/song/edit/[id].tsx:40
 msgid "Not valid URL"
 msgstr "URL non valida"
@@ -242,18 +223,14 @@ msgstr ""
 msgid "Same artist?"
 msgstr "Stesso artista?"
 
-#: app/albums/edit/[id].tsx:128
-#: app/albums/new.tsx:122
-#: app/artists/edit/[id].tsx:128
-#: app/artists/new.tsx:122
+#: app/albums/edit/[id].tsx:128 app/albums/new.tsx:122
+#: app/artists/edit/[id].tsx:128 app/artists/new.tsx:122
 #: app/song/edit/[id].tsx:193
 msgid "Save"
 msgstr "Salva"
 
-#: app/albums/edit/[id].tsx:128
-#: app/albums/new.tsx:122
-#: app/artists/edit/[id].tsx:128
-#: app/artists/new.tsx:122
+#: app/albums/edit/[id].tsx:128 app/albums/new.tsx:122
+#: app/artists/edit/[id].tsx:128 app/artists/new.tsx:122
 #: app/song/edit/[id].tsx:193
 msgid "Saving..."
 msgstr "Salvataggio..."
@@ -262,8 +239,7 @@ msgstr "Salvataggio..."
 msgid "Search songs"
 msgstr "Cerca canzoni"
 
-#: components/ui/Select.tsx:54
-#: components/ui/Select.tsx:105
+#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
 msgid "Select an option"
 msgstr ""
 
@@ -271,8 +247,7 @@ msgstr ""
 msgid "Selection canceled"
 msgstr "Selezione annullata"
 
-#: components/partials/DrawerContent.tsx:53
-#: components/partials/Heading.tsx:41
+#: components/partials/DrawerContent.tsx:53 components/partials/Heading.tsx:41
 msgid "Settings"
 msgstr "Impostazioni"
 
@@ -284,8 +259,7 @@ msgstr ""
 msgid "Song update"
 msgstr ""
 
-#: app/albums/[id].tsx:88
-#: app/artists/[id].tsx:88
+#: app/albums/[id].tsx:88 app/artists/[id].tsx:88
 #: components/partials/Heading.tsx:35
 msgid "Songs"
 msgstr "Canzoni"
@@ -298,8 +272,7 @@ msgstr ""
 msgid "The artists have been merged successfully"
 msgstr "Gli artisti sono stati uniti con successo"
 
-#: app/artists/edit/[id].tsx:43
-#: app/artists/new.tsx:29
+#: app/artists/edit/[id].tsx:43 app/artists/new.tsx:29
 msgid "The name must have at least 2 characters"
 msgstr "Il nome deve contenere almeno 2 caratteri"
 
@@ -307,42 +280,39 @@ msgstr "Il nome deve contenere almeno 2 caratteri"
 msgid "The song has been updated correctly"
 msgstr ""
 
-#: app/albums/edit/[id].tsx:43
-#: app/albums/new.tsx:29
-#: app/song/edit/[id].tsx:33
+#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
 msgid "The title must have at least 2 characters"
 msgstr ""
 
 #: app/albums/edit/[id].tsx:237
-msgid "These albums share the same title because Android reads it from the ID3 tags, which you can edit in Lissn."
+msgid ""
+"These albums share the same title because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
 msgstr ""
 
 #: app/artists/edit/[id].tsx:237
-msgid "These artists share the same name because Android reads it from the ID3 tags, which you can edit in Lissn."
-msgstr "Questi artisti condividono lo stesso nome perché Android lo legge dai tag ID3, che puoi modificare in Lissn."
+msgid ""
+"These artists share the same name because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
+msgstr ""
+"Questi artisti condividono lo stesso nome perché Android lo legge dai tag "
+"ID3, che puoi modificare in Lissn."
 
-#: components/partials/SongInfo.tsx:97
-#~ msgid "Tile"
-#~ msgstr "Riquadro"
-
-#: app/song/edit/[id].tsx:85
-#: components/partials/SongInfo.tsx:104
+#: app/song/edit/[id].tsx:85 components/partials/SongInfo.tsx:104
 msgid "Title"
 msgstr "Titolo"
 
-#: app/albums/edit/[id].tsx:44
-#: app/albums/edit/[id].tsx:47
-#: app/albums/new.tsx:30
-#: app/albums/new.tsx:33
-#: app/artists/edit/[id].tsx:44
-#: app/artists/edit/[id].tsx:47
-#: app/artists/new.tsx:30
-#: app/artists/new.tsx:33
-#: app/song/edit/[id].tsx:34
-#: app/song/edit/[id].tsx:37
+#: app/albums/edit/[id].tsx:44 app/albums/edit/[id].tsx:47
+#: app/albums/new.tsx:30 app/albums/new.tsx:33 app/artists/edit/[id].tsx:44
+#: app/artists/edit/[id].tsx:47 app/artists/new.tsx:30 app/artists/new.tsx:33
+#: app/song/edit/[id].tsx:34 app/song/edit/[id].tsx:37
 msgid "Too long"
 msgstr "Troppo lungo"
 
 #: components/partials/DrawerContent.tsx:36
 msgid "Your music app"
 msgstr "La tua app musicale"
+
+#: components/partials/SongInfo.tsx:97
+#~ msgid "Tile"
+#~ msgstr "Riquadro"

--- a/locales/ja/messages.po
+++ b/locales/ja/messages.po
@@ -1,16 +1,16 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2025-08-14 00:43+0200\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"X-Generator: @lingui/cli\n"
-"Language: ja\n"
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 00:43+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
 "Plural-Forms: \n"
 
 #: components/partials/SongInfo.tsx:151
@@ -21,8 +21,7 @@ msgstr "お気に入りに追加"
 msgid "Add to playlist"
 msgstr "プレイリストに追加"
 
-#: app/song/edit/[id].tsx:162
-#: components/partials/SongInfo.tsx:114
+#: app/song/edit/[id].tsx:162 components/partials/SongInfo.tsx:114
 msgid "Album"
 msgstr "アルバム"
 
@@ -46,8 +45,7 @@ msgstr ""
 msgid "Are you sure you want to delete the song?"
 msgstr ""
 
-#: app/song/edit/[id].tsx:131
-#: components/partials/SongInfo.tsx:108
+#: app/song/edit/[id].tsx:131 components/partials/SongInfo.tsx:108
 msgid "Artist"
 msgstr "アーティスト"
 
@@ -67,22 +65,16 @@ msgstr "アーティスト"
 msgid "Artists merged"
 msgstr "アーティストを統合しました"
 
-#: app/albums/edit/[id].tsx:103
-#: app/albums/new.tsx:97
-#: app/artists/edit/[id].tsx:103
-#: app/artists/new.tsx:97
+#: app/albums/edit/[id].tsx:103 app/albums/new.tsx:97
+#: app/artists/edit/[id].tsx:103 app/artists/new.tsx:97
 #: app/song/edit/[id].tsx:106
 msgid "Artwork URL"
 msgstr "アートワークのURL"
 
-#: app/albums/edit/[id].tsx:225
-#: app/albums/edit/[id].tsx:301
-#: app/albums/new.tsx:166
-#: app/artists/edit/[id].tsx:225
-#: app/artists/edit/[id].tsx:301
-#: app/artists/new.tsx:166
-#: app/song/edit/[id].tsx:262
-#: components/partials/SongInfo.tsx:216
+#: app/albums/edit/[id].tsx:225 app/albums/edit/[id].tsx:301
+#: app/albums/new.tsx:166 app/artists/edit/[id].tsx:225
+#: app/artists/edit/[id].tsx:301 app/artists/new.tsx:166
+#: app/song/edit/[id].tsx:262 components/partials/SongInfo.tsx:216
 msgid "Cancel"
 msgstr "キャンセル"
 
@@ -102,8 +94,7 @@ msgstr "データベースを正常にインポートしました"
 msgid "Delete"
 msgstr ""
 
-#: components/partials/SongInfo.tsx:176
-#: components/partials/SongInfo.tsx:186
+#: components/partials/SongInfo.tsx:176 components/partials/SongInfo.tsx:186
 msgid "Delete song"
 msgstr "曲を削除"
 
@@ -140,8 +131,7 @@ msgstr "お気に入り"
 msgid "GitHub Project"
 msgstr "GitHubプロジェクト"
 
-#: utils/pickAndImportDB.ts:16
-#: utils/pickAndImportDB.ts:28
+#: utils/pickAndImportDB.ts:16 utils/pickAndImportDB.ts:28
 #: utils/pickAndImportDB.ts:34
 msgid "Import database"
 msgstr "データベースをインポート"
@@ -154,8 +144,7 @@ msgstr "音楽データベースをインポート"
 msgid "Last songs"
 msgstr "最近の曲"
 
-#: app/albums/edit/[id].tsx:291
-#: app/artists/edit/[id].tsx:291
+#: app/albums/edit/[id].tsx:291 app/artists/edit/[id].tsx:291
 msgid "Merge"
 msgstr "統合"
 
@@ -167,30 +156,24 @@ msgstr ""
 msgid "Merge artists"
 msgstr "アーティストを統合"
 
-#: app/albums/edit/[id].tsx:268
-#: app/artists/edit/[id].tsx:268
+#: app/albums/edit/[id].tsx:268 app/artists/edit/[id].tsx:268
 msgid "Merge them"
 msgstr "統合する"
 
-#: app/albums/edit/[id].tsx:269
-#: app/artists/edit/[id].tsx:269
+#: app/albums/edit/[id].tsx:269 app/artists/edit/[id].tsx:269
 msgid "Merging..."
 msgstr "統合中..."
 
-#: app/albums/edit/[id].tsx:82
-#: app/albums/new.tsx:76
-#: app/artists/edit/[id].tsx:82
-#: app/artists/new.tsx:76
+#: app/albums/edit/[id].tsx:82 app/albums/new.tsx:76
+#: app/artists/edit/[id].tsx:82 app/artists/new.tsx:76
 msgid "Name"
 msgstr "名前"
 
-#: app/albums/new.tsx:65
-#: app/albums/new.tsx:150
+#: app/albums/new.tsx:65 app/albums/new.tsx:150
 msgid "New album"
 msgstr ""
 
-#: app/artists/new.tsx:65
-#: app/artists/new.tsx:150
+#: app/artists/new.tsx:65 app/artists/new.tsx:150
 msgid "New artist"
 msgstr ""
 
@@ -210,10 +193,8 @@ msgstr ""
 msgid "Nombre del artista"
 msgstr "アーティスト名"
 
-#: app/albums/edit/[id].tsx:50
-#: app/albums/new.tsx:36
-#: app/artists/edit/[id].tsx:50
-#: app/artists/new.tsx:36
+#: app/albums/edit/[id].tsx:50 app/albums/new.tsx:36
+#: app/artists/edit/[id].tsx:50 app/artists/new.tsx:36
 #: app/song/edit/[id].tsx:40
 msgid "Not valid URL"
 msgstr "無効なURL"
@@ -242,18 +223,14 @@ msgstr ""
 msgid "Same artist?"
 msgstr "同じアーティストですか？"
 
-#: app/albums/edit/[id].tsx:128
-#: app/albums/new.tsx:122
-#: app/artists/edit/[id].tsx:128
-#: app/artists/new.tsx:122
+#: app/albums/edit/[id].tsx:128 app/albums/new.tsx:122
+#: app/artists/edit/[id].tsx:128 app/artists/new.tsx:122
 #: app/song/edit/[id].tsx:193
 msgid "Save"
 msgstr "保存"
 
-#: app/albums/edit/[id].tsx:128
-#: app/albums/new.tsx:122
-#: app/artists/edit/[id].tsx:128
-#: app/artists/new.tsx:122
+#: app/albums/edit/[id].tsx:128 app/albums/new.tsx:122
+#: app/artists/edit/[id].tsx:128 app/artists/new.tsx:122
 #: app/song/edit/[id].tsx:193
 msgid "Saving..."
 msgstr "保存中..."
@@ -262,8 +239,7 @@ msgstr "保存中..."
 msgid "Search songs"
 msgstr "曲を検索"
 
-#: components/ui/Select.tsx:54
-#: components/ui/Select.tsx:105
+#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
 msgid "Select an option"
 msgstr ""
 
@@ -271,8 +247,7 @@ msgstr ""
 msgid "Selection canceled"
 msgstr "選択をキャンセルしました"
 
-#: components/partials/DrawerContent.tsx:53
-#: components/partials/Heading.tsx:41
+#: components/partials/DrawerContent.tsx:53 components/partials/Heading.tsx:41
 msgid "Settings"
 msgstr "設定"
 
@@ -284,8 +259,7 @@ msgstr ""
 msgid "Song update"
 msgstr ""
 
-#: app/albums/[id].tsx:88
-#: app/artists/[id].tsx:88
+#: app/albums/[id].tsx:88 app/artists/[id].tsx:88
 #: components/partials/Heading.tsx:35
 msgid "Songs"
 msgstr "曲"
@@ -298,8 +272,7 @@ msgstr ""
 msgid "The artists have been merged successfully"
 msgstr "アーティストは正常に統合されました"
 
-#: app/artists/edit/[id].tsx:43
-#: app/artists/new.tsx:29
+#: app/artists/edit/[id].tsx:43 app/artists/new.tsx:29
 msgid "The name must have at least 2 characters"
 msgstr "名前は2文字以上である必要があります"
 
@@ -307,42 +280,39 @@ msgstr "名前は2文字以上である必要があります"
 msgid "The song has been updated correctly"
 msgstr ""
 
-#: app/albums/edit/[id].tsx:43
-#: app/albums/new.tsx:29
-#: app/song/edit/[id].tsx:33
+#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
 msgid "The title must have at least 2 characters"
 msgstr ""
 
 #: app/albums/edit/[id].tsx:237
-msgid "These albums share the same title because Android reads it from the ID3 tags, which you can edit in Lissn."
+msgid ""
+"These albums share the same title because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
 msgstr ""
 
 #: app/artists/edit/[id].tsx:237
-msgid "These artists share the same name because Android reads it from the ID3 tags, which you can edit in Lissn."
-msgstr "これらのアーティストは同じ名前を共有しています。これは Android が ID3 タグから読み取っているためで、Lissn で編集できます。"
+msgid ""
+"These artists share the same name because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
+msgstr ""
+"これらのアーティストは同じ名前を共有しています。これは Android が ID3 タグか"
+"ら読み取っているためで、Lissn で編集できます。"
 
-#: components/partials/SongInfo.tsx:97
-#~ msgid "Tile"
-#~ msgstr "タイル"
-
-#: app/song/edit/[id].tsx:85
-#: components/partials/SongInfo.tsx:104
+#: app/song/edit/[id].tsx:85 components/partials/SongInfo.tsx:104
 msgid "Title"
 msgstr "タイトル"
 
-#: app/albums/edit/[id].tsx:44
-#: app/albums/edit/[id].tsx:47
-#: app/albums/new.tsx:30
-#: app/albums/new.tsx:33
-#: app/artists/edit/[id].tsx:44
-#: app/artists/edit/[id].tsx:47
-#: app/artists/new.tsx:30
-#: app/artists/new.tsx:33
-#: app/song/edit/[id].tsx:34
-#: app/song/edit/[id].tsx:37
+#: app/albums/edit/[id].tsx:44 app/albums/edit/[id].tsx:47
+#: app/albums/new.tsx:30 app/albums/new.tsx:33 app/artists/edit/[id].tsx:44
+#: app/artists/edit/[id].tsx:47 app/artists/new.tsx:30 app/artists/new.tsx:33
+#: app/song/edit/[id].tsx:34 app/song/edit/[id].tsx:37
 msgid "Too long"
 msgstr "長すぎます"
 
 #: components/partials/DrawerContent.tsx:36
 msgid "Your music app"
 msgstr "あなたの音楽アプリ"
+
+#: components/partials/SongInfo.tsx:97
+#~ msgid "Tile"
+#~ msgstr "タイル"

--- a/locales/ko/messages.po
+++ b/locales/ko/messages.po
@@ -1,16 +1,16 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2025-08-14 00:43+0200\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"X-Generator: @lingui/cli\n"
-"Language: ko\n"
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 00:43+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
 "Plural-Forms: \n"
 
 #: components/partials/SongInfo.tsx:151
@@ -21,8 +21,7 @@ msgstr "즐겨찾기에 추가"
 msgid "Add to playlist"
 msgstr "재생목록에 추가"
 
-#: app/song/edit/[id].tsx:162
-#: components/partials/SongInfo.tsx:114
+#: app/song/edit/[id].tsx:162 components/partials/SongInfo.tsx:114
 msgid "Album"
 msgstr "앨범"
 
@@ -46,8 +45,7 @@ msgstr ""
 msgid "Are you sure you want to delete the song?"
 msgstr ""
 
-#: app/song/edit/[id].tsx:131
-#: components/partials/SongInfo.tsx:108
+#: app/song/edit/[id].tsx:131 components/partials/SongInfo.tsx:108
 msgid "Artist"
 msgstr "아티스트"
 
@@ -67,22 +65,16 @@ msgstr "아티스트"
 msgid "Artists merged"
 msgstr "아티스트가 병합되었습니다"
 
-#: app/albums/edit/[id].tsx:103
-#: app/albums/new.tsx:97
-#: app/artists/edit/[id].tsx:103
-#: app/artists/new.tsx:97
+#: app/albums/edit/[id].tsx:103 app/albums/new.tsx:97
+#: app/artists/edit/[id].tsx:103 app/artists/new.tsx:97
 #: app/song/edit/[id].tsx:106
 msgid "Artwork URL"
 msgstr "아트워크 URL"
 
-#: app/albums/edit/[id].tsx:225
-#: app/albums/edit/[id].tsx:301
-#: app/albums/new.tsx:166
-#: app/artists/edit/[id].tsx:225
-#: app/artists/edit/[id].tsx:301
-#: app/artists/new.tsx:166
-#: app/song/edit/[id].tsx:262
-#: components/partials/SongInfo.tsx:216
+#: app/albums/edit/[id].tsx:225 app/albums/edit/[id].tsx:301
+#: app/albums/new.tsx:166 app/artists/edit/[id].tsx:225
+#: app/artists/edit/[id].tsx:301 app/artists/new.tsx:166
+#: app/song/edit/[id].tsx:262 components/partials/SongInfo.tsx:216
 msgid "Cancel"
 msgstr "취소"
 
@@ -102,8 +94,7 @@ msgstr "데이터베이스가 성공적으로 가져와졌습니다"
 msgid "Delete"
 msgstr ""
 
-#: components/partials/SongInfo.tsx:176
-#: components/partials/SongInfo.tsx:186
+#: components/partials/SongInfo.tsx:176 components/partials/SongInfo.tsx:186
 msgid "Delete song"
 msgstr "노래 삭제"
 
@@ -140,8 +131,7 @@ msgstr "즐겨찾기"
 msgid "GitHub Project"
 msgstr "GitHub 프로젝트"
 
-#: utils/pickAndImportDB.ts:16
-#: utils/pickAndImportDB.ts:28
+#: utils/pickAndImportDB.ts:16 utils/pickAndImportDB.ts:28
 #: utils/pickAndImportDB.ts:34
 msgid "Import database"
 msgstr "데이터베이스 가져오기"
@@ -154,8 +144,7 @@ msgstr "음악 데이터베이스 가져오기"
 msgid "Last songs"
 msgstr "최근 노래"
 
-#: app/albums/edit/[id].tsx:291
-#: app/artists/edit/[id].tsx:291
+#: app/albums/edit/[id].tsx:291 app/artists/edit/[id].tsx:291
 msgid "Merge"
 msgstr "병합"
 
@@ -167,30 +156,24 @@ msgstr ""
 msgid "Merge artists"
 msgstr "아티스트 병합"
 
-#: app/albums/edit/[id].tsx:268
-#: app/artists/edit/[id].tsx:268
+#: app/albums/edit/[id].tsx:268 app/artists/edit/[id].tsx:268
 msgid "Merge them"
 msgstr "병합하기"
 
-#: app/albums/edit/[id].tsx:269
-#: app/artists/edit/[id].tsx:269
+#: app/albums/edit/[id].tsx:269 app/artists/edit/[id].tsx:269
 msgid "Merging..."
 msgstr "병합 중..."
 
-#: app/albums/edit/[id].tsx:82
-#: app/albums/new.tsx:76
-#: app/artists/edit/[id].tsx:82
-#: app/artists/new.tsx:76
+#: app/albums/edit/[id].tsx:82 app/albums/new.tsx:76
+#: app/artists/edit/[id].tsx:82 app/artists/new.tsx:76
 msgid "Name"
 msgstr "이름"
 
-#: app/albums/new.tsx:65
-#: app/albums/new.tsx:150
+#: app/albums/new.tsx:65 app/albums/new.tsx:150
 msgid "New album"
 msgstr ""
 
-#: app/artists/new.tsx:65
-#: app/artists/new.tsx:150
+#: app/artists/new.tsx:65 app/artists/new.tsx:150
 msgid "New artist"
 msgstr ""
 
@@ -210,10 +193,8 @@ msgstr ""
 msgid "Nombre del artista"
 msgstr "아티스트 이름"
 
-#: app/albums/edit/[id].tsx:50
-#: app/albums/new.tsx:36
-#: app/artists/edit/[id].tsx:50
-#: app/artists/new.tsx:36
+#: app/albums/edit/[id].tsx:50 app/albums/new.tsx:36
+#: app/artists/edit/[id].tsx:50 app/artists/new.tsx:36
 #: app/song/edit/[id].tsx:40
 msgid "Not valid URL"
 msgstr "유효하지 않은 URL"
@@ -242,18 +223,14 @@ msgstr ""
 msgid "Same artist?"
 msgstr "같은 아티스트인가요?"
 
-#: app/albums/edit/[id].tsx:128
-#: app/albums/new.tsx:122
-#: app/artists/edit/[id].tsx:128
-#: app/artists/new.tsx:122
+#: app/albums/edit/[id].tsx:128 app/albums/new.tsx:122
+#: app/artists/edit/[id].tsx:128 app/artists/new.tsx:122
 #: app/song/edit/[id].tsx:193
 msgid "Save"
 msgstr "저장"
 
-#: app/albums/edit/[id].tsx:128
-#: app/albums/new.tsx:122
-#: app/artists/edit/[id].tsx:128
-#: app/artists/new.tsx:122
+#: app/albums/edit/[id].tsx:128 app/albums/new.tsx:122
+#: app/artists/edit/[id].tsx:128 app/artists/new.tsx:122
 #: app/song/edit/[id].tsx:193
 msgid "Saving..."
 msgstr "저장 중..."
@@ -262,8 +239,7 @@ msgstr "저장 중..."
 msgid "Search songs"
 msgstr "노래 검색"
 
-#: components/ui/Select.tsx:54
-#: components/ui/Select.tsx:105
+#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
 msgid "Select an option"
 msgstr ""
 
@@ -271,8 +247,7 @@ msgstr ""
 msgid "Selection canceled"
 msgstr "선택이 취소되었습니다"
 
-#: components/partials/DrawerContent.tsx:53
-#: components/partials/Heading.tsx:41
+#: components/partials/DrawerContent.tsx:53 components/partials/Heading.tsx:41
 msgid "Settings"
 msgstr "설정"
 
@@ -284,8 +259,7 @@ msgstr ""
 msgid "Song update"
 msgstr ""
 
-#: app/albums/[id].tsx:88
-#: app/artists/[id].tsx:88
+#: app/albums/[id].tsx:88 app/artists/[id].tsx:88
 #: components/partials/Heading.tsx:35
 msgid "Songs"
 msgstr "노래"
@@ -298,8 +272,7 @@ msgstr ""
 msgid "The artists have been merged successfully"
 msgstr "아티스트가 성공적으로 병합되었습니다"
 
-#: app/artists/edit/[id].tsx:43
-#: app/artists/new.tsx:29
+#: app/artists/edit/[id].tsx:43 app/artists/new.tsx:29
 msgid "The name must have at least 2 characters"
 msgstr "이름은 최소 두 글자여야 합니다"
 
@@ -307,42 +280,39 @@ msgstr "이름은 최소 두 글자여야 합니다"
 msgid "The song has been updated correctly"
 msgstr ""
 
-#: app/albums/edit/[id].tsx:43
-#: app/albums/new.tsx:29
-#: app/song/edit/[id].tsx:33
+#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
 msgid "The title must have at least 2 characters"
 msgstr ""
 
 #: app/albums/edit/[id].tsx:237
-msgid "These albums share the same title because Android reads it from the ID3 tags, which you can edit in Lissn."
+msgid ""
+"These albums share the same title because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
 msgstr ""
 
 #: app/artists/edit/[id].tsx:237
-msgid "These artists share the same name because Android reads it from the ID3 tags, which you can edit in Lissn."
-msgstr "이 아티스트들은 동일한 이름을 사용합니다. 이는 Android가 ID3 태그에서 이름을 읽기 때문이며, Lissn에서 편집할 수 있습니다."
+msgid ""
+"These artists share the same name because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
+msgstr ""
+"이 아티스트들은 동일한 이름을 사용합니다. 이는 Android가 ID3 태그에서 이름을 "
+"읽기 때문이며, Lissn에서 편집할 수 있습니다."
 
-#: components/partials/SongInfo.tsx:97
-#~ msgid "Tile"
-#~ msgstr "타일"
-
-#: app/song/edit/[id].tsx:85
-#: components/partials/SongInfo.tsx:104
+#: app/song/edit/[id].tsx:85 components/partials/SongInfo.tsx:104
 msgid "Title"
 msgstr "제목"
 
-#: app/albums/edit/[id].tsx:44
-#: app/albums/edit/[id].tsx:47
-#: app/albums/new.tsx:30
-#: app/albums/new.tsx:33
-#: app/artists/edit/[id].tsx:44
-#: app/artists/edit/[id].tsx:47
-#: app/artists/new.tsx:30
-#: app/artists/new.tsx:33
-#: app/song/edit/[id].tsx:34
-#: app/song/edit/[id].tsx:37
+#: app/albums/edit/[id].tsx:44 app/albums/edit/[id].tsx:47
+#: app/albums/new.tsx:30 app/albums/new.tsx:33 app/artists/edit/[id].tsx:44
+#: app/artists/edit/[id].tsx:47 app/artists/new.tsx:30 app/artists/new.tsx:33
+#: app/song/edit/[id].tsx:34 app/song/edit/[id].tsx:37
 msgid "Too long"
 msgstr "너무 깁니다"
 
 #: components/partials/DrawerContent.tsx:36
 msgid "Your music app"
 msgstr "당신의 음악 앱"
+
+#: components/partials/SongInfo.tsx:97
+#~ msgid "Tile"
+#~ msgstr "타일"

--- a/locales/zh/messages.po
+++ b/locales/zh/messages.po
@@ -1,16 +1,16 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2025-08-14 00:43+0200\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"X-Generator: @lingui/cli\n"
-"Language: zh\n"
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-14 00:43+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: zh\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
 "Plural-Forms: \n"
 
 #: components/partials/SongInfo.tsx:151
@@ -21,8 +21,7 @@ msgstr "添加到收藏"
 msgid "Add to playlist"
 msgstr "添加到播放列表"
 
-#: app/song/edit/[id].tsx:162
-#: components/partials/SongInfo.tsx:114
+#: app/song/edit/[id].tsx:162 components/partials/SongInfo.tsx:114
 msgid "Album"
 msgstr "专辑"
 
@@ -46,8 +45,7 @@ msgstr ""
 msgid "Are you sure you want to delete the song?"
 msgstr ""
 
-#: app/song/edit/[id].tsx:131
-#: components/partials/SongInfo.tsx:108
+#: app/song/edit/[id].tsx:131 components/partials/SongInfo.tsx:108
 msgid "Artist"
 msgstr "艺术家"
 
@@ -67,22 +65,16 @@ msgstr "艺术家"
 msgid "Artists merged"
 msgstr "艺术家已合并"
 
-#: app/albums/edit/[id].tsx:103
-#: app/albums/new.tsx:97
-#: app/artists/edit/[id].tsx:103
-#: app/artists/new.tsx:97
+#: app/albums/edit/[id].tsx:103 app/albums/new.tsx:97
+#: app/artists/edit/[id].tsx:103 app/artists/new.tsx:97
 #: app/song/edit/[id].tsx:106
 msgid "Artwork URL"
 msgstr "封面网址"
 
-#: app/albums/edit/[id].tsx:225
-#: app/albums/edit/[id].tsx:301
-#: app/albums/new.tsx:166
-#: app/artists/edit/[id].tsx:225
-#: app/artists/edit/[id].tsx:301
-#: app/artists/new.tsx:166
-#: app/song/edit/[id].tsx:262
-#: components/partials/SongInfo.tsx:216
+#: app/albums/edit/[id].tsx:225 app/albums/edit/[id].tsx:301
+#: app/albums/new.tsx:166 app/artists/edit/[id].tsx:225
+#: app/artists/edit/[id].tsx:301 app/artists/new.tsx:166
+#: app/song/edit/[id].tsx:262 components/partials/SongInfo.tsx:216
 msgid "Cancel"
 msgstr "取消"
 
@@ -102,8 +94,7 @@ msgstr "数据库导入成功"
 msgid "Delete"
 msgstr ""
 
-#: components/partials/SongInfo.tsx:176
-#: components/partials/SongInfo.tsx:186
+#: components/partials/SongInfo.tsx:176 components/partials/SongInfo.tsx:186
 msgid "Delete song"
 msgstr "删除歌曲"
 
@@ -140,8 +131,7 @@ msgstr "收藏"
 msgid "GitHub Project"
 msgstr "GitHub 项目"
 
-#: utils/pickAndImportDB.ts:16
-#: utils/pickAndImportDB.ts:28
+#: utils/pickAndImportDB.ts:16 utils/pickAndImportDB.ts:28
 #: utils/pickAndImportDB.ts:34
 msgid "Import database"
 msgstr "导入数据库"
@@ -154,8 +144,7 @@ msgstr "导入音乐数据库"
 msgid "Last songs"
 msgstr "最近的歌曲"
 
-#: app/albums/edit/[id].tsx:291
-#: app/artists/edit/[id].tsx:291
+#: app/albums/edit/[id].tsx:291 app/artists/edit/[id].tsx:291
 msgid "Merge"
 msgstr "合并"
 
@@ -167,30 +156,24 @@ msgstr ""
 msgid "Merge artists"
 msgstr "合并艺术家"
 
-#: app/albums/edit/[id].tsx:268
-#: app/artists/edit/[id].tsx:268
+#: app/albums/edit/[id].tsx:268 app/artists/edit/[id].tsx:268
 msgid "Merge them"
 msgstr "合并它们"
 
-#: app/albums/edit/[id].tsx:269
-#: app/artists/edit/[id].tsx:269
+#: app/albums/edit/[id].tsx:269 app/artists/edit/[id].tsx:269
 msgid "Merging..."
 msgstr "正在合并..."
 
-#: app/albums/edit/[id].tsx:82
-#: app/albums/new.tsx:76
-#: app/artists/edit/[id].tsx:82
-#: app/artists/new.tsx:76
+#: app/albums/edit/[id].tsx:82 app/albums/new.tsx:76
+#: app/artists/edit/[id].tsx:82 app/artists/new.tsx:76
 msgid "Name"
 msgstr "名称"
 
-#: app/albums/new.tsx:65
-#: app/albums/new.tsx:150
+#: app/albums/new.tsx:65 app/albums/new.tsx:150
 msgid "New album"
 msgstr ""
 
-#: app/artists/new.tsx:65
-#: app/artists/new.tsx:150
+#: app/artists/new.tsx:65 app/artists/new.tsx:150
 msgid "New artist"
 msgstr ""
 
@@ -210,10 +193,8 @@ msgstr ""
 msgid "Nombre del artista"
 msgstr "艺术家名称"
 
-#: app/albums/edit/[id].tsx:50
-#: app/albums/new.tsx:36
-#: app/artists/edit/[id].tsx:50
-#: app/artists/new.tsx:36
+#: app/albums/edit/[id].tsx:50 app/albums/new.tsx:36
+#: app/artists/edit/[id].tsx:50 app/artists/new.tsx:36
 #: app/song/edit/[id].tsx:40
 msgid "Not valid URL"
 msgstr "无效的 URL"
@@ -242,18 +223,14 @@ msgstr ""
 msgid "Same artist?"
 msgstr "相同的艺术家？"
 
-#: app/albums/edit/[id].tsx:128
-#: app/albums/new.tsx:122
-#: app/artists/edit/[id].tsx:128
-#: app/artists/new.tsx:122
+#: app/albums/edit/[id].tsx:128 app/albums/new.tsx:122
+#: app/artists/edit/[id].tsx:128 app/artists/new.tsx:122
 #: app/song/edit/[id].tsx:193
 msgid "Save"
 msgstr "保存"
 
-#: app/albums/edit/[id].tsx:128
-#: app/albums/new.tsx:122
-#: app/artists/edit/[id].tsx:128
-#: app/artists/new.tsx:122
+#: app/albums/edit/[id].tsx:128 app/albums/new.tsx:122
+#: app/artists/edit/[id].tsx:128 app/artists/new.tsx:122
 #: app/song/edit/[id].tsx:193
 msgid "Saving..."
 msgstr "正在保存..."
@@ -262,8 +239,7 @@ msgstr "正在保存..."
 msgid "Search songs"
 msgstr "搜索歌曲"
 
-#: components/ui/Select.tsx:54
-#: components/ui/Select.tsx:105
+#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
 msgid "Select an option"
 msgstr ""
 
@@ -271,8 +247,7 @@ msgstr ""
 msgid "Selection canceled"
 msgstr "选择已取消"
 
-#: components/partials/DrawerContent.tsx:53
-#: components/partials/Heading.tsx:41
+#: components/partials/DrawerContent.tsx:53 components/partials/Heading.tsx:41
 msgid "Settings"
 msgstr "设置"
 
@@ -284,8 +259,7 @@ msgstr ""
 msgid "Song update"
 msgstr ""
 
-#: app/albums/[id].tsx:88
-#: app/artists/[id].tsx:88
+#: app/albums/[id].tsx:88 app/artists/[id].tsx:88
 #: components/partials/Heading.tsx:35
 msgid "Songs"
 msgstr "歌曲"
@@ -298,8 +272,7 @@ msgstr ""
 msgid "The artists have been merged successfully"
 msgstr "艺术家已成功合并"
 
-#: app/artists/edit/[id].tsx:43
-#: app/artists/new.tsx:29
+#: app/artists/edit/[id].tsx:43 app/artists/new.tsx:29
 msgid "The name must have at least 2 characters"
 msgstr "名称至少需要2个字符"
 
@@ -307,42 +280,39 @@ msgstr "名称至少需要2个字符"
 msgid "The song has been updated correctly"
 msgstr ""
 
-#: app/albums/edit/[id].tsx:43
-#: app/albums/new.tsx:29
-#: app/song/edit/[id].tsx:33
+#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
 msgid "The title must have at least 2 characters"
 msgstr ""
 
 #: app/albums/edit/[id].tsx:237
-msgid "These albums share the same title because Android reads it from the ID3 tags, which you can edit in Lissn."
+msgid ""
+"These albums share the same title because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
 msgstr ""
 
 #: app/artists/edit/[id].tsx:237
-msgid "These artists share the same name because Android reads it from the ID3 tags, which you can edit in Lissn."
-msgstr "这些艺术家共享同一个名字，因为 Android 从 ID3 标签中读取它，你可以在 Lissn 中编辑。"
+msgid ""
+"These artists share the same name because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
+msgstr ""
+"这些艺术家共享同一个名字，因为 Android 从 ID3 标签中读取它，你可以在 Lissn 中"
+"编辑。"
 
-#: components/partials/SongInfo.tsx:97
-#~ msgid "Tile"
-#~ msgstr "磁贴"
-
-#: app/song/edit/[id].tsx:85
-#: components/partials/SongInfo.tsx:104
+#: app/song/edit/[id].tsx:85 components/partials/SongInfo.tsx:104
 msgid "Title"
 msgstr "标题"
 
-#: app/albums/edit/[id].tsx:44
-#: app/albums/edit/[id].tsx:47
-#: app/albums/new.tsx:30
-#: app/albums/new.tsx:33
-#: app/artists/edit/[id].tsx:44
-#: app/artists/edit/[id].tsx:47
-#: app/artists/new.tsx:30
-#: app/artists/new.tsx:33
-#: app/song/edit/[id].tsx:34
-#: app/song/edit/[id].tsx:37
+#: app/albums/edit/[id].tsx:44 app/albums/edit/[id].tsx:47
+#: app/albums/new.tsx:30 app/albums/new.tsx:33 app/artists/edit/[id].tsx:44
+#: app/artists/edit/[id].tsx:47 app/artists/new.tsx:30 app/artists/new.tsx:33
+#: app/song/edit/[id].tsx:34 app/song/edit/[id].tsx:37
 msgid "Too long"
 msgstr "太长"
 
 #: components/partials/DrawerContent.tsx:36
 msgid "Your music app"
 msgstr "你的音乐应用"
+
+#: components/partials/SongInfo.tsx:97
+#~ msgid "Tile"
+#~ msgstr "磁贴"


### PR DESCRIPTION
## Summary
- merge English template into all locale `messages.po`
- no npm commands run; only gettext tools

## Testing
- `for lang in ar de es fr hi it ja ko zh en; do msgfmt --check -o /tmp/$lang.mo locales/$lang/messages.po; done`


------
https://chatgpt.com/codex/tasks/task_e_68ab7625e3bc833099447c55686c5dc0