### PR TITLE
Translate remaining locale strings

### DIFF
--- a/locales/ar/messages.po
+++ b/locales/ar/messages.po
@@ -25,37 +25,9 @@ msgstr "أضف إلى قائمة التشغيل"
 msgid "Album"
 msgstr "ألبوم"
 
-#: app/albums/new.tsx:66
-msgid "Album created successfully"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:93
-msgid "Album name"
-msgstr ""
-
-#: components/partials/DrawerContent.tsx:44
-msgid "Albums"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:176
-msgid "Albums merged"
-msgstr ""
-
-#: components/partials/SongInfo.tsx:189
-msgid "Are you sure you want to delete the song?"
-msgstr ""
-
 #: app/song/edit/[id].tsx:131 components/partials/SongInfo.tsx:108
 msgid "Artist"
 msgstr "فنان"
-
-#: app/artists/new.tsx:66
-msgid "Artist created successfully"
-msgstr ""
-
-#: app/artists/edit/[id].tsx:93
-msgid "Artist name"
-msgstr ""
 
 #: components/partials/Heading.tsx:39
 msgid "Artists"
@@ -78,29 +50,13 @@ msgstr "رابط الصورة"
 msgid "Cancel"
 msgstr "إلغاء"
 
-#: app/song/edit/[id].tsx:187
-msgid "Create new album"
-msgstr ""
-
-#: app/song/edit/[id].tsx:156
-msgid "Create new artist"
-msgstr ""
-
 #: utils/pickAndImportDB.ts:29
 msgid "Database imported successfully"
 msgstr "تم استيراد قاعدة البيانات بنجاح"
 
-#: components/partials/SongInfo.tsx:206
-msgid "Delete"
-msgstr ""
-
 #: components/partials/SongInfo.tsx:176 components/partials/SongInfo.tsx:186
 msgid "Delete song"
 msgstr "حذف الأغنية"
-
-#: app/albums/edit/[id].tsx:208
-msgid "Edit album"
-msgstr ""
 
 #: app/artists/edit/[id].tsx:208
 msgid "Edit artist"
@@ -109,10 +65,6 @@ msgstr "تعديل الفنان"
 #: components/partials/SongInfo.tsx:167
 msgid "Edit details"
 msgstr "تعديل التفاصيل"
-
-#: app/song/edit/[id].tsx:245
-msgid "Edit song"
-msgstr ""
 
 #. js-lingui-explicit-id
 #: utils/pickAndImportDB.ts:36
@@ -148,10 +100,6 @@ msgstr "آخر الأغاني"
 msgid "Merge"
 msgstr "دمج"
 
-#: app/albums/edit/[id].tsx:279
-msgid "Merge albums"
-msgstr ""
-
 #: app/artists/edit/[id].tsx:279
 msgid "Merge artists"
 msgstr "دمج الفنانين"
@@ -169,25 +117,9 @@ msgstr "جارٍ الدمج..."
 msgid "Name"
 msgstr "الاسم"
 
-#: app/albums/new.tsx:65 app/albums/new.tsx:150
-msgid "New album"
-msgstr ""
-
-#: app/artists/new.tsx:65 app/artists/new.tsx:150
-msgid "New artist"
-msgstr ""
-
-#: app/albums/[id].tsx:48
-msgid "No album found"
-msgstr ""
-
 #: app/artists/[id].tsx:48
 msgid "No artist found"
 msgstr "لم يتم العثور على فنان"
-
-#: app/albums/new.tsx:87
-msgid "Nombre del albuma"
-msgstr ""
 
 #: app/artists/new.tsx:87
 msgid "Nombre del artista"
@@ -215,10 +147,6 @@ msgstr "تم التشغيل مؤخراً"
 msgid "Remove from favorites"
 msgstr "إزالة من المفضلة"
 
-#: app/albums/edit/[id].tsx:234
-msgid "Same album?"
-msgstr ""
-
 #: app/artists/edit/[id].tsx:234
 msgid "Same artist?"
 msgstr "نفس الفنان؟"
@@ -239,10 +167,6 @@ msgstr "جارٍ الحفظ..."
 msgid "Search songs"
 msgstr "البحث عن الأغاني"
 
-#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
-msgid "Select an option"
-msgstr ""
-
 #: utils/pickAndImportDB.ts:17
 msgid "Selection canceled"
 msgstr "تم إلغاء التحديد"
@@ -251,22 +175,10 @@ msgstr "تم إلغاء التحديد"
 msgid "Settings"
 msgstr "الإعدادات"
 
-#: app/song/edit/[id].tsx:96
-msgid "Song name"
-msgstr ""
-
-#: app/song/edit/[id].tsx:75
-msgid "Song update"
-msgstr ""
-
 #: app/albums/[id].tsx:88 app/artists/[id].tsx:88
 #: components/partials/Heading.tsx:35
 msgid "Songs"
 msgstr "أغانٍ"
-
-#: app/albums/edit/[id].tsx:177
-msgid "The albums have been merged successfully"
-msgstr ""
 
 #: app/artists/edit/[id].tsx:177
 msgid "The artists have been merged successfully"
@@ -275,20 +187,6 @@ msgstr "تم دمج الفنانين بنجاح"
 #: app/artists/edit/[id].tsx:43 app/artists/new.tsx:29
 msgid "The name must have at least 2 characters"
 msgstr "يجب أن يحتوي الاسم على حرفين على الأقل"
-
-#: app/song/edit/[id].tsx:76
-msgid "The song has been updated correctly"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
-msgid "The title must have at least 2 characters"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:237
-msgid ""
-"These albums share the same title because Android reads it from the ID3 "
-"tags, which you can edit in Lissn."
-msgstr ""
 
 #: app/artists/edit/[id].tsx:237
 msgid ""
@@ -312,6 +210,110 @@ msgstr "طويل جداً"
 #: components/partials/DrawerContent.tsx:36
 msgid "Your music app"
 msgstr "تطبيق الموسيقى الخاص بك"
+
+#: app/albums/new.tsx:66
+msgid "Album created successfully"
+msgstr "تم إنشاء الألبوم بنجاح"
+
+#: app/albums/edit/[id].tsx:93
+msgid "Album name"
+msgstr "اسم الألبوم"
+
+#: components/partials/DrawerContent.tsx:44
+msgid "Albums"
+msgstr "الألبومات"
+
+#: app/albums/edit/[id].tsx:176
+msgid "Albums merged"
+msgstr "تم دمج الألبومات"
+
+#: components/partials/SongInfo.tsx:189
+msgid "Are you sure you want to delete the song?"
+msgstr "هل أنت متأكد أنك تريد حذف الأغنية؟"
+
+#: app/artists/new.tsx:66
+msgid "Artist created successfully"
+msgstr "تم إنشاء الفنان بنجاح"
+
+#: app/artists/edit/[id].tsx:93
+msgid "Artist name"
+msgstr "اسم الفنان"
+
+#: app/song/edit/[id].tsx:187
+msgid "Create new album"
+msgstr "إنشاء ألبوم جديد"
+
+#: app/song/edit/[id].tsx:156
+msgid "Create new artist"
+msgstr "إنشاء فنان جديد"
+
+#: components/partials/SongInfo.tsx:206
+msgid "Delete"
+msgstr "حذف"
+
+#: app/albums/edit/[id].tsx:208
+msgid "Edit album"
+msgstr "تعديل الألبوم"
+
+#: app/song/edit/[id].tsx:245
+msgid "Edit song"
+msgstr "تعديل الأغنية"
+
+#: app/albums/edit/[id].tsx:279
+msgid "Merge albums"
+msgstr "دمج الألبومات"
+
+#: app/albums/new.tsx:65 app/albums/new.tsx:150
+msgid "New album"
+msgstr "ألبوم جديد"
+
+#: app/artists/new.tsx:65 app/artists/new.tsx:150
+msgid "New artist"
+msgstr "فنان جديد"
+
+#: app/albums/[id].tsx:48
+msgid "No album found"
+msgstr "لم يتم العثور على ألبوم"
+
+#: app/albums/new.tsx:87
+msgid "Nombre del albuma"
+msgstr "اسم الألبوم"
+
+#: app/albums/edit/[id].tsx:234
+msgid "Same album?"
+msgstr "نفس الألبوم؟"
+
+#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
+msgid "Select an option"
+msgstr "اختر خيارًا"
+
+#: app/song/edit/[id].tsx:96
+msgid "Song name"
+msgstr "اسم الأغنية"
+
+#: app/song/edit/[id].tsx:75
+msgid "Song update"
+msgstr "تحديث الأغنية"
+
+#: app/albums/edit/[id].tsx:177
+msgid "The albums have been merged successfully"
+msgstr "تم دمج الألبومات بنجاح"
+
+#: app/song/edit/[id].tsx:76
+msgid "The song has been updated correctly"
+msgstr "تم تحديث الأغنية بنجاح"
+
+#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
+msgid "The title must have at least 2 characters"
+msgstr "يجب أن يحتوي العنوان على حرفين على الأقل"
+
+#: app/albums/edit/[id].tsx:237
+msgid ""
+"These albums share the same title because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
+msgstr ""
+"تشارك هذه الألبومات العنوان نفسه لأن أندرويد يقرأه من وسوم ID3 التي يمكنك "
+"تعديلها في Lissn."
 
 #: components/partials/SongInfo.tsx:97
 #~ msgid "Tile"

--- a/locales/de/messages.po
+++ b/locales/de/messages.po
@@ -25,37 +25,9 @@ msgstr "Zur Playlist hinzufügen"
 msgid "Album"
 msgstr "Album"
 
-#: app/albums/new.tsx:66
-msgid "Album created successfully"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:93
-msgid "Album name"
-msgstr ""
-
-#: components/partials/DrawerContent.tsx:44
-msgid "Albums"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:176
-msgid "Albums merged"
-msgstr ""
-
-#: components/partials/SongInfo.tsx:189
-msgid "Are you sure you want to delete the song?"
-msgstr ""
-
 #: app/song/edit/[id].tsx:131 components/partials/SongInfo.tsx:108
 msgid "Artist"
 msgstr "Künstler"
-
-#: app/artists/new.tsx:66
-msgid "Artist created successfully"
-msgstr ""
-
-#: app/artists/edit/[id].tsx:93
-msgid "Artist name"
-msgstr ""
 
 #: components/partials/Heading.tsx:39
 msgid "Artists"
@@ -78,29 +50,13 @@ msgstr "Artwork-URL"
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: app/song/edit/[id].tsx:187
-msgid "Create new album"
-msgstr ""
-
-#: app/song/edit/[id].tsx:156
-msgid "Create new artist"
-msgstr ""
-
 #: utils/pickAndImportDB.ts:29
 msgid "Database imported successfully"
 msgstr "Datenbank erfolgreich importiert"
 
-#: components/partials/SongInfo.tsx:206
-msgid "Delete"
-msgstr ""
-
 #: components/partials/SongInfo.tsx:176 components/partials/SongInfo.tsx:186
 msgid "Delete song"
 msgstr "Song löschen"
-
-#: app/albums/edit/[id].tsx:208
-msgid "Edit album"
-msgstr ""
 
 #: app/artists/edit/[id].tsx:208
 msgid "Edit artist"
@@ -109,10 +65,6 @@ msgstr "Künstler bearbeiten"
 #: components/partials/SongInfo.tsx:167
 msgid "Edit details"
 msgstr "Details bearbeiten"
-
-#: app/song/edit/[id].tsx:245
-msgid "Edit song"
-msgstr ""
 
 #. js-lingui-explicit-id
 #: utils/pickAndImportDB.ts:36
@@ -148,10 +100,6 @@ msgstr "Letzte Songs"
 msgid "Merge"
 msgstr "Zusammenführen"
 
-#: app/albums/edit/[id].tsx:279
-msgid "Merge albums"
-msgstr ""
-
 #: app/artists/edit/[id].tsx:279
 msgid "Merge artists"
 msgstr "Künstler zusammenführen"
@@ -169,25 +117,9 @@ msgstr "Wird zusammengeführt..."
 msgid "Name"
 msgstr "Name"
 
-#: app/albums/new.tsx:65 app/albums/new.tsx:150
-msgid "New album"
-msgstr ""
-
-#: app/artists/new.tsx:65 app/artists/new.tsx:150
-msgid "New artist"
-msgstr ""
-
-#: app/albums/[id].tsx:48
-msgid "No album found"
-msgstr ""
-
 #: app/artists/[id].tsx:48
 msgid "No artist found"
 msgstr "Kein Künstler gefunden"
-
-#: app/albums/new.tsx:87
-msgid "Nombre del albuma"
-msgstr ""
 
 #: app/artists/new.tsx:87
 msgid "Nombre del artista"
@@ -215,10 +147,6 @@ msgstr "Kürzlich gespielt"
 msgid "Remove from favorites"
 msgstr "Aus Favoriten entfernen"
 
-#: app/albums/edit/[id].tsx:234
-msgid "Same album?"
-msgstr ""
-
 #: app/artists/edit/[id].tsx:234
 msgid "Same artist?"
 msgstr "Gleicher Künstler?"
@@ -239,10 +167,6 @@ msgstr "Speichern..."
 msgid "Search songs"
 msgstr "Songs suchen"
 
-#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
-msgid "Select an option"
-msgstr ""
-
 #: utils/pickAndImportDB.ts:17
 msgid "Selection canceled"
 msgstr "Auswahl abgebrochen"
@@ -251,22 +175,10 @@ msgstr "Auswahl abgebrochen"
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: app/song/edit/[id].tsx:96
-msgid "Song name"
-msgstr ""
-
-#: app/song/edit/[id].tsx:75
-msgid "Song update"
-msgstr ""
-
 #: app/albums/[id].tsx:88 app/artists/[id].tsx:88
 #: components/partials/Heading.tsx:35
 msgid "Songs"
 msgstr "Songs"
-
-#: app/albums/edit/[id].tsx:177
-msgid "The albums have been merged successfully"
-msgstr ""
 
 #: app/artists/edit/[id].tsx:177
 msgid "The artists have been merged successfully"
@@ -275,20 +187,6 @@ msgstr "Die Künstler wurden erfolgreich zusammengeführt"
 #: app/artists/edit/[id].tsx:43 app/artists/new.tsx:29
 msgid "The name must have at least 2 characters"
 msgstr "Der Name muss mindestens 2 Zeichen haben"
-
-#: app/song/edit/[id].tsx:76
-msgid "The song has been updated correctly"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
-msgid "The title must have at least 2 characters"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:237
-msgid ""
-"These albums share the same title because Android reads it from the ID3 "
-"tags, which you can edit in Lissn."
-msgstr ""
 
 #: app/artists/edit/[id].tsx:237
 msgid ""
@@ -312,6 +210,110 @@ msgstr "Zu lang"
 #: components/partials/DrawerContent.tsx:36
 msgid "Your music app"
 msgstr "Deine Musik-App"
+
+#: app/albums/new.tsx:66
+msgid "Album created successfully"
+msgstr "Album erfolgreich erstellt"
+
+#: app/albums/edit/[id].tsx:93
+msgid "Album name"
+msgstr "Albumname"
+
+#: components/partials/DrawerContent.tsx:44
+msgid "Albums"
+msgstr "Alben"
+
+#: app/albums/edit/[id].tsx:176
+msgid "Albums merged"
+msgstr "Alben zusammengeführt"
+
+#: components/partials/SongInfo.tsx:189
+msgid "Are you sure you want to delete the song?"
+msgstr "Bist du sicher, dass du das Lied löschen möchtest?"
+
+#: app/artists/new.tsx:66
+msgid "Artist created successfully"
+msgstr "Künstler erfolgreich erstellt"
+
+#: app/artists/edit/[id].tsx:93
+msgid "Artist name"
+msgstr "Künstlername"
+
+#: app/song/edit/[id].tsx:187
+msgid "Create new album"
+msgstr "Neues Album erstellen"
+
+#: app/song/edit/[id].tsx:156
+msgid "Create new artist"
+msgstr "Neuen Künstler erstellen"
+
+#: components/partials/SongInfo.tsx:206
+msgid "Delete"
+msgstr "Löschen"
+
+#: app/albums/edit/[id].tsx:208
+msgid "Edit album"
+msgstr "Album bearbeiten"
+
+#: app/song/edit/[id].tsx:245
+msgid "Edit song"
+msgstr "Lied bearbeiten"
+
+#: app/albums/edit/[id].tsx:279
+msgid "Merge albums"
+msgstr "Alben zusammenführen"
+
+#: app/albums/new.tsx:65 app/albums/new.tsx:150
+msgid "New album"
+msgstr "Neues Album"
+
+#: app/artists/new.tsx:65 app/artists/new.tsx:150
+msgid "New artist"
+msgstr "Neuer Künstler"
+
+#: app/albums/[id].tsx:48
+msgid "No album found"
+msgstr "Kein Album gefunden"
+
+#: app/albums/new.tsx:87
+msgid "Nombre del albuma"
+msgstr "Albumname"
+
+#: app/albums/edit/[id].tsx:234
+msgid "Same album?"
+msgstr "Gleiches Album?"
+
+#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
+msgid "Select an option"
+msgstr "Option auswählen"
+
+#: app/song/edit/[id].tsx:96
+msgid "Song name"
+msgstr "Liedname"
+
+#: app/song/edit/[id].tsx:75
+msgid "Song update"
+msgstr "Lied aktualisiert"
+
+#: app/albums/edit/[id].tsx:177
+msgid "The albums have been merged successfully"
+msgstr "Die Alben wurden erfolgreich zusammengeführt"
+
+#: app/song/edit/[id].tsx:76
+msgid "The song has been updated correctly"
+msgstr "Das Lied wurde erfolgreich aktualisiert"
+
+#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
+msgid "The title must have at least 2 characters"
+msgstr "Der Titel muss mindestens 2 Zeichen haben"
+
+#: app/albums/edit/[id].tsx:237
+msgid ""
+"These albums share the same title because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
+msgstr ""
+"Diese Alben teilen denselben Titel, weil Android ihn aus den ID3-Tags liest, "
+"die du in Lissn bearbeiten kannst."
 
 #: components/partials/SongInfo.tsx:97
 #~ msgid "Tile"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -25,37 +25,9 @@ msgstr "Añadir a la lista de reproducción"
 msgid "Album"
 msgstr "Álbum"
 
-#: app/albums/new.tsx:66
-msgid "Album created successfully"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:93
-msgid "Album name"
-msgstr ""
-
-#: components/partials/DrawerContent.tsx:44
-msgid "Albums"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:176
-msgid "Albums merged"
-msgstr ""
-
-#: components/partials/SongInfo.tsx:189
-msgid "Are you sure you want to delete the song?"
-msgstr ""
-
 #: app/song/edit/[id].tsx:131 components/partials/SongInfo.tsx:108
 msgid "Artist"
 msgstr "Artista"
-
-#: app/artists/new.tsx:66
-msgid "Artist created successfully"
-msgstr ""
-
-#: app/artists/edit/[id].tsx:93
-msgid "Artist name"
-msgstr ""
 
 #: components/partials/Heading.tsx:39
 msgid "Artists"
@@ -78,29 +50,13 @@ msgstr "URL de la portada"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: app/song/edit/[id].tsx:187
-msgid "Create new album"
-msgstr ""
-
-#: app/song/edit/[id].tsx:156
-msgid "Create new artist"
-msgstr ""
-
 #: utils/pickAndImportDB.ts:29
 msgid "Database imported successfully"
 msgstr "Base de datos importada correctamente"
 
-#: components/partials/SongInfo.tsx:206
-msgid "Delete"
-msgstr ""
-
 #: components/partials/SongInfo.tsx:176 components/partials/SongInfo.tsx:186
 msgid "Delete song"
 msgstr "Eliminar canción"
-
-#: app/albums/edit/[id].tsx:208
-msgid "Edit album"
-msgstr ""
 
 #: app/artists/edit/[id].tsx:208
 msgid "Edit artist"
@@ -109,10 +65,6 @@ msgstr "Editar artista"
 #: components/partials/SongInfo.tsx:167
 msgid "Edit details"
 msgstr "Editar detalles"
-
-#: app/song/edit/[id].tsx:245
-msgid "Edit song"
-msgstr ""
 
 #. js-lingui-explicit-id
 #: utils/pickAndImportDB.ts:36
@@ -148,10 +100,6 @@ msgstr "Últimas canciones"
 msgid "Merge"
 msgstr "Fusionar"
 
-#: app/albums/edit/[id].tsx:279
-msgid "Merge albums"
-msgstr ""
-
 #: app/artists/edit/[id].tsx:279
 msgid "Merge artists"
 msgstr "Fusionar artistas"
@@ -169,25 +117,9 @@ msgstr "Fusionando..."
 msgid "Name"
 msgstr "Nombre"
 
-#: app/albums/new.tsx:65 app/albums/new.tsx:150
-msgid "New album"
-msgstr ""
-
-#: app/artists/new.tsx:65 app/artists/new.tsx:150
-msgid "New artist"
-msgstr ""
-
-#: app/albums/[id].tsx:48
-msgid "No album found"
-msgstr ""
-
 #: app/artists/[id].tsx:48
 msgid "No artist found"
 msgstr "No se encontró ningún artista"
-
-#: app/albums/new.tsx:87
-msgid "Nombre del albuma"
-msgstr ""
 
 #: app/artists/new.tsx:87
 msgid "Nombre del artista"
@@ -215,10 +147,6 @@ msgstr "Reproducciones recientes"
 msgid "Remove from favorites"
 msgstr "Eliminar de favoritos"
 
-#: app/albums/edit/[id].tsx:234
-msgid "Same album?"
-msgstr ""
-
 #: app/artists/edit/[id].tsx:234
 msgid "Same artist?"
 msgstr "¿El mismo artista?"
@@ -239,10 +167,6 @@ msgstr "Guardando..."
 msgid "Search songs"
 msgstr "Buscar canciones"
 
-#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
-msgid "Select an option"
-msgstr ""
-
 #: utils/pickAndImportDB.ts:17
 msgid "Selection canceled"
 msgstr "Selección cancelada"
@@ -251,22 +175,10 @@ msgstr "Selección cancelada"
 msgid "Settings"
 msgstr "Configuración"
 
-#: app/song/edit/[id].tsx:96
-msgid "Song name"
-msgstr ""
-
-#: app/song/edit/[id].tsx:75
-msgid "Song update"
-msgstr ""
-
 #: app/albums/[id].tsx:88 app/artists/[id].tsx:88
 #: components/partials/Heading.tsx:35
 msgid "Songs"
 msgstr "Canciones"
-
-#: app/albums/edit/[id].tsx:177
-msgid "The albums have been merged successfully"
-msgstr ""
 
 #: app/artists/edit/[id].tsx:177
 msgid "The artists have been merged successfully"
@@ -275,20 +187,6 @@ msgstr "Los artistas se han fusionado correctamente"
 #: app/artists/edit/[id].tsx:43 app/artists/new.tsx:29
 msgid "The name must have at least 2 characters"
 msgstr "El nombre debe tener al menos 2 caracteres"
-
-#: app/song/edit/[id].tsx:76
-msgid "The song has been updated correctly"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
-msgid "The title must have at least 2 characters"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:237
-msgid ""
-"These albums share the same title because Android reads it from the ID3 "
-"tags, which you can edit in Lissn."
-msgstr ""
 
 #: app/artists/edit/[id].tsx:237
 msgid ""
@@ -312,6 +210,110 @@ msgstr "Demasiado largo"
 #: components/partials/DrawerContent.tsx:36
 msgid "Your music app"
 msgstr "Tu aplicación de música"
+
+#: app/albums/new.tsx:66
+msgid "Album created successfully"
+msgstr "Álbum creado correctamente"
+
+#: app/albums/edit/[id].tsx:93
+msgid "Album name"
+msgstr "Nombre del álbum"
+
+#: components/partials/DrawerContent.tsx:44
+msgid "Albums"
+msgstr "Álbumes"
+
+#: app/albums/edit/[id].tsx:176
+msgid "Albums merged"
+msgstr "Álbumes fusionados"
+
+#: components/partials/SongInfo.tsx:189
+msgid "Are you sure you want to delete the song?"
+msgstr "¿Seguro que quieres eliminar la canción?"
+
+#: app/artists/new.tsx:66
+msgid "Artist created successfully"
+msgstr "Artista creado correctamente"
+
+#: app/artists/edit/[id].tsx:93
+msgid "Artist name"
+msgstr "Nombre del artista"
+
+#: app/song/edit/[id].tsx:187
+msgid "Create new album"
+msgstr "Crear nuevo álbum"
+
+#: app/song/edit/[id].tsx:156
+msgid "Create new artist"
+msgstr "Crear nuevo artista"
+
+#: components/partials/SongInfo.tsx:206
+msgid "Delete"
+msgstr "Eliminar"
+
+#: app/albums/edit/[id].tsx:208
+msgid "Edit album"
+msgstr "Editar álbum"
+
+#: app/song/edit/[id].tsx:245
+msgid "Edit song"
+msgstr "Editar canción"
+
+#: app/albums/edit/[id].tsx:279
+msgid "Merge albums"
+msgstr "Fusionar álbumes"
+
+#: app/albums/new.tsx:65 app/albums/new.tsx:150
+msgid "New album"
+msgstr "Nuevo álbum"
+
+#: app/artists/new.tsx:65 app/artists/new.tsx:150
+msgid "New artist"
+msgstr "Nuevo artista"
+
+#: app/albums/[id].tsx:48
+msgid "No album found"
+msgstr "No se encontró ningún álbum"
+
+#: app/albums/new.tsx:87
+msgid "Nombre del albuma"
+msgstr "Nombre del álbum"
+
+#: app/albums/edit/[id].tsx:234
+msgid "Same album?"
+msgstr "¿El mismo álbum?"
+
+#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
+msgid "Select an option"
+msgstr "Selecciona una opción"
+
+#: app/song/edit/[id].tsx:96
+msgid "Song name"
+msgstr "Nombre de la canción"
+
+#: app/song/edit/[id].tsx:75
+msgid "Song update"
+msgstr "Actualización de la canción"
+
+#: app/albums/edit/[id].tsx:177
+msgid "The albums have been merged successfully"
+msgstr "Los álbumes se han fusionado correctamente"
+
+#: app/song/edit/[id].tsx:76
+msgid "The song has been updated correctly"
+msgstr "La canción se ha actualizado correctamente"
+
+#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
+msgid "The title must have at least 2 characters"
+msgstr "El título debe tener al menos 2 caracteres"
+
+#: app/albums/edit/[id].tsx:237
+msgid ""
+"These albums share the same title because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
+msgstr ""
+"Estos álbumes comparten el mismo título porque Android lo lee de las "
+"etiquetas ID3, que puedes editar en Lissn."
 
 #: components/partials/SongInfo.tsx:97
 #~ msgid "Tile"

--- a/locales/fr/messages.po
+++ b/locales/fr/messages.po
@@ -25,37 +25,9 @@ msgstr "Ajouter à la playlist"
 msgid "Album"
 msgstr "Album"
 
-#: app/albums/new.tsx:66
-msgid "Album created successfully"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:93
-msgid "Album name"
-msgstr ""
-
-#: components/partials/DrawerContent.tsx:44
-msgid "Albums"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:176
-msgid "Albums merged"
-msgstr ""
-
-#: components/partials/SongInfo.tsx:189
-msgid "Are you sure you want to delete the song?"
-msgstr ""
-
 #: app/song/edit/[id].tsx:131 components/partials/SongInfo.tsx:108
 msgid "Artist"
 msgstr "Artiste"
-
-#: app/artists/new.tsx:66
-msgid "Artist created successfully"
-msgstr ""
-
-#: app/artists/edit/[id].tsx:93
-msgid "Artist name"
-msgstr ""
 
 #: components/partials/Heading.tsx:39
 msgid "Artists"
@@ -78,29 +50,13 @@ msgstr "URL de l'illustration"
 msgid "Cancel"
 msgstr "Annuler"
 
-#: app/song/edit/[id].tsx:187
-msgid "Create new album"
-msgstr ""
-
-#: app/song/edit/[id].tsx:156
-msgid "Create new artist"
-msgstr ""
-
 #: utils/pickAndImportDB.ts:29
 msgid "Database imported successfully"
 msgstr "Base de données importée avec succès"
 
-#: components/partials/SongInfo.tsx:206
-msgid "Delete"
-msgstr ""
-
 #: components/partials/SongInfo.tsx:176 components/partials/SongInfo.tsx:186
 msgid "Delete song"
 msgstr "Supprimer la chanson"
-
-#: app/albums/edit/[id].tsx:208
-msgid "Edit album"
-msgstr ""
 
 #: app/artists/edit/[id].tsx:208
 msgid "Edit artist"
@@ -109,10 +65,6 @@ msgstr "Modifier l'artiste"
 #: components/partials/SongInfo.tsx:167
 msgid "Edit details"
 msgstr "Modifier les détails"
-
-#: app/song/edit/[id].tsx:245
-msgid "Edit song"
-msgstr ""
 
 #. js-lingui-explicit-id
 #: utils/pickAndImportDB.ts:36
@@ -148,10 +100,6 @@ msgstr "Dernières chansons"
 msgid "Merge"
 msgstr "Fusionner"
 
-#: app/albums/edit/[id].tsx:279
-msgid "Merge albums"
-msgstr ""
-
 #: app/artists/edit/[id].tsx:279
 msgid "Merge artists"
 msgstr "Fusionner les artistes"
@@ -169,25 +117,9 @@ msgstr "Fusion en cours..."
 msgid "Name"
 msgstr "Nom"
 
-#: app/albums/new.tsx:65 app/albums/new.tsx:150
-msgid "New album"
-msgstr ""
-
-#: app/artists/new.tsx:65 app/artists/new.tsx:150
-msgid "New artist"
-msgstr ""
-
-#: app/albums/[id].tsx:48
-msgid "No album found"
-msgstr ""
-
 #: app/artists/[id].tsx:48
 msgid "No artist found"
 msgstr "Aucun artiste trouvé"
-
-#: app/albums/new.tsx:87
-msgid "Nombre del albuma"
-msgstr ""
 
 #: app/artists/new.tsx:87
 msgid "Nombre del artista"
@@ -215,10 +147,6 @@ msgstr "Récemment jouées"
 msgid "Remove from favorites"
 msgstr "Retirer des favoris"
 
-#: app/albums/edit/[id].tsx:234
-msgid "Same album?"
-msgstr ""
-
 #: app/artists/edit/[id].tsx:234
 msgid "Same artist?"
 msgstr "Même artiste ?"
@@ -239,10 +167,6 @@ msgstr "Enregistrement..."
 msgid "Search songs"
 msgstr "Rechercher des chansons"
 
-#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
-msgid "Select an option"
-msgstr ""
-
 #: utils/pickAndImportDB.ts:17
 msgid "Selection canceled"
 msgstr "Sélection annulée"
@@ -251,22 +175,10 @@ msgstr "Sélection annulée"
 msgid "Settings"
 msgstr "Paramètres"
 
-#: app/song/edit/[id].tsx:96
-msgid "Song name"
-msgstr ""
-
-#: app/song/edit/[id].tsx:75
-msgid "Song update"
-msgstr ""
-
 #: app/albums/[id].tsx:88 app/artists/[id].tsx:88
 #: components/partials/Heading.tsx:35
 msgid "Songs"
 msgstr "Chansons"
-
-#: app/albums/edit/[id].tsx:177
-msgid "The albums have been merged successfully"
-msgstr ""
 
 #: app/artists/edit/[id].tsx:177
 msgid "The artists have been merged successfully"
@@ -275,20 +187,6 @@ msgstr "Les artistes ont été fusionnés avec succès"
 #: app/artists/edit/[id].tsx:43 app/artists/new.tsx:29
 msgid "The name must have at least 2 characters"
 msgstr "Le nom doit comporter au moins 2 caractères"
-
-#: app/song/edit/[id].tsx:76
-msgid "The song has been updated correctly"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
-msgid "The title must have at least 2 characters"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:237
-msgid ""
-"These albums share the same title because Android reads it from the ID3 "
-"tags, which you can edit in Lissn."
-msgstr ""
 
 #: app/artists/edit/[id].tsx:237
 msgid ""
@@ -312,6 +210,110 @@ msgstr "Trop long"
 #: components/partials/DrawerContent.tsx:36
 msgid "Your music app"
 msgstr "Votre application musicale"
+
+#: app/albums/new.tsx:66
+msgid "Album created successfully"
+msgstr "Album créé avec succès"
+
+#: app/albums/edit/[id].tsx:93
+msgid "Album name"
+msgstr "Nom de l'album"
+
+#: components/partials/DrawerContent.tsx:44
+msgid "Albums"
+msgstr "Albums"
+
+#: app/albums/edit/[id].tsx:176
+msgid "Albums merged"
+msgstr "Albums fusionnés"
+
+#: components/partials/SongInfo.tsx:189
+msgid "Are you sure you want to delete the song?"
+msgstr "Êtes-vous sûr de vouloir supprimer la chanson ?"
+
+#: app/artists/new.tsx:66
+msgid "Artist created successfully"
+msgstr "Artiste créé avec succès"
+
+#: app/artists/edit/[id].tsx:93
+msgid "Artist name"
+msgstr "Nom de l'artiste"
+
+#: app/song/edit/[id].tsx:187
+msgid "Create new album"
+msgstr "Créer un nouvel album"
+
+#: app/song/edit/[id].tsx:156
+msgid "Create new artist"
+msgstr "Créer un nouvel artiste"
+
+#: components/partials/SongInfo.tsx:206
+msgid "Delete"
+msgstr "Supprimer"
+
+#: app/albums/edit/[id].tsx:208
+msgid "Edit album"
+msgstr "Modifier l'album"
+
+#: app/song/edit/[id].tsx:245
+msgid "Edit song"
+msgstr "Modifier la chanson"
+
+#: app/albums/edit/[id].tsx:279
+msgid "Merge albums"
+msgstr "Fusionner les albums"
+
+#: app/albums/new.tsx:65 app/albums/new.tsx:150
+msgid "New album"
+msgstr "Nouvel album"
+
+#: app/artists/new.tsx:65 app/artists/new.tsx:150
+msgid "New artist"
+msgstr "Nouvel artiste"
+
+#: app/albums/[id].tsx:48
+msgid "No album found"
+msgstr "Aucun album trouvé"
+
+#: app/albums/new.tsx:87
+msgid "Nombre del albuma"
+msgstr "Nom de l'album"
+
+#: app/albums/edit/[id].tsx:234
+msgid "Same album?"
+msgstr "Même album ?"
+
+#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
+msgid "Select an option"
+msgstr "Sélectionnez une option"
+
+#: app/song/edit/[id].tsx:96
+msgid "Song name"
+msgstr "Nom de la chanson"
+
+#: app/song/edit/[id].tsx:75
+msgid "Song update"
+msgstr "Mise à jour de la chanson"
+
+#: app/albums/edit/[id].tsx:177
+msgid "The albums have been merged successfully"
+msgstr "Les albums ont été fusionnés avec succès"
+
+#: app/song/edit/[id].tsx:76
+msgid "The song has been updated correctly"
+msgstr "La chanson a été mise à jour avec succès"
+
+#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
+msgid "The title must have at least 2 characters"
+msgstr "Le titre doit comporter au moins 2 caractères"
+
+#: app/albums/edit/[id].tsx:237
+msgid ""
+"These albums share the same title because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
+msgstr ""
+"Ces albums partagent le même titre car Android le lit depuis les balises ID3, "
+"que vous pouvez modifier dans Lissn."
 
 #: components/partials/SongInfo.tsx:97
 #~ msgid "Tile"

--- a/locales/hi/messages.po
+++ b/locales/hi/messages.po
@@ -25,37 +25,9 @@ msgstr "प्लेलिस्ट में जोड़ें"
 msgid "Album"
 msgstr "एल्बम"
 
-#: app/albums/new.tsx:66
-msgid "Album created successfully"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:93
-msgid "Album name"
-msgstr ""
-
-#: components/partials/DrawerContent.tsx:44
-msgid "Albums"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:176
-msgid "Albums merged"
-msgstr ""
-
-#: components/partials/SongInfo.tsx:189
-msgid "Are you sure you want to delete the song?"
-msgstr ""
-
 #: app/song/edit/[id].tsx:131 components/partials/SongInfo.tsx:108
 msgid "Artist"
 msgstr "कलाकार"
-
-#: app/artists/new.tsx:66
-msgid "Artist created successfully"
-msgstr ""
-
-#: app/artists/edit/[id].tsx:93
-msgid "Artist name"
-msgstr ""
 
 #: components/partials/Heading.tsx:39
 msgid "Artists"
@@ -78,29 +50,13 @@ msgstr "कलाकृति URL"
 msgid "Cancel"
 msgstr "रद्द करें"
 
-#: app/song/edit/[id].tsx:187
-msgid "Create new album"
-msgstr ""
-
-#: app/song/edit/[id].tsx:156
-msgid "Create new artist"
-msgstr ""
-
 #: utils/pickAndImportDB.ts:29
 msgid "Database imported successfully"
 msgstr "डेटाबेस सफलतापूर्वक आयात किया गया"
 
-#: components/partials/SongInfo.tsx:206
-msgid "Delete"
-msgstr ""
-
 #: components/partials/SongInfo.tsx:176 components/partials/SongInfo.tsx:186
 msgid "Delete song"
 msgstr "गीत हटाएं"
-
-#: app/albums/edit/[id].tsx:208
-msgid "Edit album"
-msgstr ""
 
 #: app/artists/edit/[id].tsx:208
 msgid "Edit artist"
@@ -109,10 +65,6 @@ msgstr "कलाकार संपादित करें"
 #: components/partials/SongInfo.tsx:167
 msgid "Edit details"
 msgstr "विवरण संपादित करें"
-
-#: app/song/edit/[id].tsx:245
-msgid "Edit song"
-msgstr ""
 
 #. js-lingui-explicit-id
 #: utils/pickAndImportDB.ts:36
@@ -148,10 +100,6 @@ msgstr "आखिरी गीत"
 msgid "Merge"
 msgstr "मिलाएँ"
 
-#: app/albums/edit/[id].tsx:279
-msgid "Merge albums"
-msgstr ""
-
 #: app/artists/edit/[id].tsx:279
 msgid "Merge artists"
 msgstr "कलाकारों को मिलाएँ"
@@ -169,25 +117,9 @@ msgstr "मिला रहे हैं..."
 msgid "Name"
 msgstr "नाम"
 
-#: app/albums/new.tsx:65 app/albums/new.tsx:150
-msgid "New album"
-msgstr ""
-
-#: app/artists/new.tsx:65 app/artists/new.tsx:150
-msgid "New artist"
-msgstr ""
-
-#: app/albums/[id].tsx:48
-msgid "No album found"
-msgstr ""
-
 #: app/artists/[id].tsx:48
 msgid "No artist found"
 msgstr "कोई कलाकार नहीं मिला"
-
-#: app/albums/new.tsx:87
-msgid "Nombre del albuma"
-msgstr ""
 
 #: app/artists/new.tsx:87
 msgid "Nombre del artista"
@@ -215,10 +147,6 @@ msgstr "हाल ही में चलाए गए"
 msgid "Remove from favorites"
 msgstr "पसंदीदा से हटाएं"
 
-#: app/albums/edit/[id].tsx:234
-msgid "Same album?"
-msgstr ""
-
 #: app/artists/edit/[id].tsx:234
 msgid "Same artist?"
 msgstr "क्या वही कलाकार है?"
@@ -239,10 +167,6 @@ msgstr "सहेजा जा रहा है..."
 msgid "Search songs"
 msgstr "गीत खोजें"
 
-#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
-msgid "Select an option"
-msgstr ""
-
 #: utils/pickAndImportDB.ts:17
 msgid "Selection canceled"
 msgstr "चयन रद्द किया गया"
@@ -251,22 +175,10 @@ msgstr "चयन रद्द किया गया"
 msgid "Settings"
 msgstr "सेटिंग्स"
 
-#: app/song/edit/[id].tsx:96
-msgid "Song name"
-msgstr ""
-
-#: app/song/edit/[id].tsx:75
-msgid "Song update"
-msgstr ""
-
 #: app/albums/[id].tsx:88 app/artists/[id].tsx:88
 #: components/partials/Heading.tsx:35
 msgid "Songs"
 msgstr "गीत"
-
-#: app/albums/edit/[id].tsx:177
-msgid "The albums have been merged successfully"
-msgstr ""
 
 #: app/artists/edit/[id].tsx:177
 msgid "The artists have been merged successfully"
@@ -275,20 +187,6 @@ msgstr "कलाकारों को सफलतापूर्वक मि
 #: app/artists/edit/[id].tsx:43 app/artists/new.tsx:29
 msgid "The name must have at least 2 characters"
 msgstr "नाम में कम से कम 2 अक्षर होने चाहिए"
-
-#: app/song/edit/[id].tsx:76
-msgid "The song has been updated correctly"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
-msgid "The title must have at least 2 characters"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:237
-msgid ""
-"These albums share the same title because Android reads it from the ID3 "
-"tags, which you can edit in Lissn."
-msgstr ""
 
 #: app/artists/edit/[id].tsx:237
 msgid ""
@@ -312,6 +210,109 @@ msgstr "बहुत लंबा"
 #: components/partials/DrawerContent.tsx:36
 msgid "Your music app"
 msgstr "आपका संगीत ऐप"
+
+#: app/albums/new.tsx:66
+msgid "Album created successfully"
+msgstr "एल्बम सफलतापूर्वक बनाया गया"
+
+#: app/albums/edit/[id].tsx:93
+msgid "Album name"
+msgstr "एल्बम का नाम"
+
+#: components/partials/DrawerContent.tsx:44
+msgid "Albums"
+msgstr "एल्बम"
+
+#: app/albums/edit/[id].tsx:176
+msgid "Albums merged"
+msgstr "एल्बम मर्ज किए गए"
+
+#: components/partials/SongInfo.tsx:189
+msgid "Are you sure you want to delete the song?"
+msgstr "क्या आप वाकई गाना हटाना चाहते हैं?"
+
+#: app/artists/new.tsx:66
+msgid "Artist created successfully"
+msgstr "कलाकार सफलतापूर्वक बनाया गया"
+
+#: app/artists/edit/[id].tsx:93
+msgid "Artist name"
+msgstr "कलाकार का नाम"
+
+#: app/song/edit/[id].tsx:187
+msgid "Create new album"
+msgstr "नया एल्बम बनाएं"
+
+#: app/song/edit/[id].tsx:156
+msgid "Create new artist"
+msgstr "नया कलाकार बनाएं"
+
+#: components/partials/SongInfo.tsx:206
+msgid "Delete"
+msgstr "हटाएं"
+
+#: app/albums/edit/[id].tsx:208
+msgid "Edit album"
+msgstr "एल्बम संपादित करें"
+
+#: app/song/edit/[id].tsx:245
+msgid "Edit song"
+msgstr "गाना संपादित करें"
+
+#: app/albums/edit/[id].tsx:279
+msgid "Merge albums"
+msgstr "एल्बम मर्ज करें"
+
+#: app/albums/new.tsx:65 app/albums/new.tsx:150
+msgid "New album"
+msgstr "नया एल्बम"
+
+#: app/artists/new.tsx:65 app/artists/new.tsx:150
+msgid "New artist"
+msgstr "नया कलाकार"
+
+#: app/albums/[id].tsx:48
+msgid "No album found"
+msgstr "कोई एल्बम नहीं मिला"
+
+#: app/albums/new.tsx:87
+msgid "Nombre del albuma"
+msgstr "एल्बम का नाम"
+
+#: app/albums/edit/[id].tsx:234
+msgid "Same album?"
+msgstr "क्या वही एल्बम?"
+
+#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
+msgid "Select an option"
+msgstr "एक विकल्प चुनें"
+
+#: app/song/edit/[id].tsx:96
+msgid "Song name"
+msgstr "गाने का नाम"
+
+#: app/song/edit/[id].tsx:75
+msgid "Song update"
+msgstr "गाने का अपडेट"
+
+#: app/albums/edit/[id].tsx:177
+msgid "The albums have been merged successfully"
+msgstr "एल्बम सफलतापूर्वक मर्ज किए गए हैं"
+
+#: app/song/edit/[id].tsx:76
+msgid "The song has been updated correctly"
+msgstr "गाना सफलतापूर्वक अपडेट किया गया है"
+
+#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
+msgid "The title must have at least 2 characters"
+msgstr "शीर्षक में कम से कम 2 अक्षर होने चाहिए"
+
+#: app/albums/edit/[id].tsx:237
+msgid ""
+"These albums share the same title because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
+msgstr ""
+"इन एल्बमों का शीर्षक समान है क्योंकि एंड्रॉइड इसे ID3 टैग से पढ़ता है, जिन्हें आप Lissn में संपादित कर सकते हैं।"
 
 #: components/partials/SongInfo.tsx:97
 #~ msgid "Tile"

--- a/locales/it/messages.po
+++ b/locales/it/messages.po
@@ -25,37 +25,9 @@ msgstr "Aggiungi alla playlist"
 msgid "Album"
 msgstr "Album"
 
-#: app/albums/new.tsx:66
-msgid "Album created successfully"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:93
-msgid "Album name"
-msgstr ""
-
-#: components/partials/DrawerContent.tsx:44
-msgid "Albums"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:176
-msgid "Albums merged"
-msgstr ""
-
-#: components/partials/SongInfo.tsx:189
-msgid "Are you sure you want to delete the song?"
-msgstr ""
-
 #: app/song/edit/[id].tsx:131 components/partials/SongInfo.tsx:108
 msgid "Artist"
 msgstr "Artista"
-
-#: app/artists/new.tsx:66
-msgid "Artist created successfully"
-msgstr ""
-
-#: app/artists/edit/[id].tsx:93
-msgid "Artist name"
-msgstr ""
 
 #: components/partials/Heading.tsx:39
 msgid "Artists"
@@ -78,29 +50,13 @@ msgstr "URL della copertina"
 msgid "Cancel"
 msgstr "Annulla"
 
-#: app/song/edit/[id].tsx:187
-msgid "Create new album"
-msgstr ""
-
-#: app/song/edit/[id].tsx:156
-msgid "Create new artist"
-msgstr ""
-
 #: utils/pickAndImportDB.ts:29
 msgid "Database imported successfully"
 msgstr "Database importato con successo"
 
-#: components/partials/SongInfo.tsx:206
-msgid "Delete"
-msgstr ""
-
 #: components/partials/SongInfo.tsx:176 components/partials/SongInfo.tsx:186
 msgid "Delete song"
 msgstr "Elimina canzone"
-
-#: app/albums/edit/[id].tsx:208
-msgid "Edit album"
-msgstr ""
 
 #: app/artists/edit/[id].tsx:208
 msgid "Edit artist"
@@ -109,10 +65,6 @@ msgstr "Modifica artista"
 #: components/partials/SongInfo.tsx:167
 msgid "Edit details"
 msgstr "Modifica dettagli"
-
-#: app/song/edit/[id].tsx:245
-msgid "Edit song"
-msgstr ""
 
 #. js-lingui-explicit-id
 #: utils/pickAndImportDB.ts:36
@@ -148,10 +100,6 @@ msgstr "Ultime canzoni"
 msgid "Merge"
 msgstr "Unisci"
 
-#: app/albums/edit/[id].tsx:279
-msgid "Merge albums"
-msgstr ""
-
 #: app/artists/edit/[id].tsx:279
 msgid "Merge artists"
 msgstr "Unisci artisti"
@@ -169,25 +117,9 @@ msgstr "Unione in corso..."
 msgid "Name"
 msgstr "Nome"
 
-#: app/albums/new.tsx:65 app/albums/new.tsx:150
-msgid "New album"
-msgstr ""
-
-#: app/artists/new.tsx:65 app/artists/new.tsx:150
-msgid "New artist"
-msgstr ""
-
-#: app/albums/[id].tsx:48
-msgid "No album found"
-msgstr ""
-
 #: app/artists/[id].tsx:48
 msgid "No artist found"
 msgstr "Nessun artista trovato"
-
-#: app/albums/new.tsx:87
-msgid "Nombre del albuma"
-msgstr ""
 
 #: app/artists/new.tsx:87
 msgid "Nombre del artista"
@@ -215,10 +147,6 @@ msgstr "Riprodotte di recente"
 msgid "Remove from favorites"
 msgstr "Rimuovi dai preferiti"
 
-#: app/albums/edit/[id].tsx:234
-msgid "Same album?"
-msgstr ""
-
 #: app/artists/edit/[id].tsx:234
 msgid "Same artist?"
 msgstr "Stesso artista?"
@@ -239,10 +167,6 @@ msgstr "Salvataggio..."
 msgid "Search songs"
 msgstr "Cerca canzoni"
 
-#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
-msgid "Select an option"
-msgstr ""
-
 #: utils/pickAndImportDB.ts:17
 msgid "Selection canceled"
 msgstr "Selezione annullata"
@@ -251,22 +175,10 @@ msgstr "Selezione annullata"
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: app/song/edit/[id].tsx:96
-msgid "Song name"
-msgstr ""
-
-#: app/song/edit/[id].tsx:75
-msgid "Song update"
-msgstr ""
-
 #: app/albums/[id].tsx:88 app/artists/[id].tsx:88
 #: components/partials/Heading.tsx:35
 msgid "Songs"
 msgstr "Canzoni"
-
-#: app/albums/edit/[id].tsx:177
-msgid "The albums have been merged successfully"
-msgstr ""
 
 #: app/artists/edit/[id].tsx:177
 msgid "The artists have been merged successfully"
@@ -275,20 +187,6 @@ msgstr "Gli artisti sono stati uniti con successo"
 #: app/artists/edit/[id].tsx:43 app/artists/new.tsx:29
 msgid "The name must have at least 2 characters"
 msgstr "Il nome deve contenere almeno 2 caratteri"
-
-#: app/song/edit/[id].tsx:76
-msgid "The song has been updated correctly"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
-msgid "The title must have at least 2 characters"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:237
-msgid ""
-"These albums share the same title because Android reads it from the ID3 "
-"tags, which you can edit in Lissn."
-msgstr ""
 
 #: app/artists/edit/[id].tsx:237
 msgid ""
@@ -312,6 +210,110 @@ msgstr "Troppo lungo"
 #: components/partials/DrawerContent.tsx:36
 msgid "Your music app"
 msgstr "La tua app musicale"
+
+#: app/albums/new.tsx:66
+msgid "Album created successfully"
+msgstr "Album creato con successo"
+
+#: app/albums/edit/[id].tsx:93
+msgid "Album name"
+msgstr "Nome dell'album"
+
+#: components/partials/DrawerContent.tsx:44
+msgid "Albums"
+msgstr "Album"
+
+#: app/albums/edit/[id].tsx:176
+msgid "Albums merged"
+msgstr "Album uniti"
+
+#: components/partials/SongInfo.tsx:189
+msgid "Are you sure you want to delete the song?"
+msgstr "Sei sicuro di voler eliminare la canzone?"
+
+#: app/artists/new.tsx:66
+msgid "Artist created successfully"
+msgstr "Artista creato con successo"
+
+#: app/artists/edit/[id].tsx:93
+msgid "Artist name"
+msgstr "Nome dell'artista"
+
+#: app/song/edit/[id].tsx:187
+msgid "Create new album"
+msgstr "Crea nuovo album"
+
+#: app/song/edit/[id].tsx:156
+msgid "Create new artist"
+msgstr "Crea nuovo artista"
+
+#: components/partials/SongInfo.tsx:206
+msgid "Delete"
+msgstr "Elimina"
+
+#: app/albums/edit/[id].tsx:208
+msgid "Edit album"
+msgstr "Modifica album"
+
+#: app/song/edit/[id].tsx:245
+msgid "Edit song"
+msgstr "Modifica canzone"
+
+#: app/albums/edit/[id].tsx:279
+msgid "Merge albums"
+msgstr "Unisci album"
+
+#: app/albums/new.tsx:65 app/albums/new.tsx:150
+msgid "New album"
+msgstr "Nuovo album"
+
+#: app/artists/new.tsx:65 app/artists/new.tsx:150
+msgid "New artist"
+msgstr "Nuovo artista"
+
+#: app/albums/[id].tsx:48
+msgid "No album found"
+msgstr "Nessun album trovato"
+
+#: app/albums/new.tsx:87
+msgid "Nombre del albuma"
+msgstr "Nome dell'album"
+
+#: app/albums/edit/[id].tsx:234
+msgid "Same album?"
+msgstr "Stesso album?"
+
+#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
+msgid "Select an option"
+msgstr "Seleziona un'opzione"
+
+#: app/song/edit/[id].tsx:96
+msgid "Song name"
+msgstr "Nome della canzone"
+
+#: app/song/edit/[id].tsx:75
+msgid "Song update"
+msgstr "Aggiornamento canzone"
+
+#: app/albums/edit/[id].tsx:177
+msgid "The albums have been merged successfully"
+msgstr "Gli album sono stati uniti con successo"
+
+#: app/song/edit/[id].tsx:76
+msgid "The song has been updated correctly"
+msgstr "La canzone è stata aggiornata correttamente"
+
+#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
+msgid "The title must have at least 2 characters"
+msgstr "Il titolo deve contenere almeno 2 caratteri"
+
+#: app/albums/edit/[id].tsx:237
+msgid ""
+"These albums share the same title because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
+msgstr ""
+"Questi album condividono lo stesso titolo perché Android lo legge dai tag ID3, "
+"che puoi modificare in Lissn."
 
 #: components/partials/SongInfo.tsx:97
 #~ msgid "Tile"

--- a/locales/ja/messages.po
+++ b/locales/ja/messages.po
@@ -25,37 +25,9 @@ msgstr "プレイリストに追加"
 msgid "Album"
 msgstr "アルバム"
 
-#: app/albums/new.tsx:66
-msgid "Album created successfully"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:93
-msgid "Album name"
-msgstr ""
-
-#: components/partials/DrawerContent.tsx:44
-msgid "Albums"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:176
-msgid "Albums merged"
-msgstr ""
-
-#: components/partials/SongInfo.tsx:189
-msgid "Are you sure you want to delete the song?"
-msgstr ""
-
 #: app/song/edit/[id].tsx:131 components/partials/SongInfo.tsx:108
 msgid "Artist"
 msgstr "アーティスト"
-
-#: app/artists/new.tsx:66
-msgid "Artist created successfully"
-msgstr ""
-
-#: app/artists/edit/[id].tsx:93
-msgid "Artist name"
-msgstr ""
 
 #: components/partials/Heading.tsx:39
 msgid "Artists"
@@ -78,29 +50,13 @@ msgstr "アートワークのURL"
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: app/song/edit/[id].tsx:187
-msgid "Create new album"
-msgstr ""
-
-#: app/song/edit/[id].tsx:156
-msgid "Create new artist"
-msgstr ""
-
 #: utils/pickAndImportDB.ts:29
 msgid "Database imported successfully"
 msgstr "データベースを正常にインポートしました"
 
-#: components/partials/SongInfo.tsx:206
-msgid "Delete"
-msgstr ""
-
 #: components/partials/SongInfo.tsx:176 components/partials/SongInfo.tsx:186
 msgid "Delete song"
 msgstr "曲を削除"
-
-#: app/albums/edit/[id].tsx:208
-msgid "Edit album"
-msgstr ""
 
 #: app/artists/edit/[id].tsx:208
 msgid "Edit artist"
@@ -109,10 +65,6 @@ msgstr "アーティストを編集"
 #: components/partials/SongInfo.tsx:167
 msgid "Edit details"
 msgstr "詳細を編集"
-
-#: app/song/edit/[id].tsx:245
-msgid "Edit song"
-msgstr ""
 
 #. js-lingui-explicit-id
 #: utils/pickAndImportDB.ts:36
@@ -148,10 +100,6 @@ msgstr "最近の曲"
 msgid "Merge"
 msgstr "統合"
 
-#: app/albums/edit/[id].tsx:279
-msgid "Merge albums"
-msgstr ""
-
 #: app/artists/edit/[id].tsx:279
 msgid "Merge artists"
 msgstr "アーティストを統合"
@@ -169,25 +117,9 @@ msgstr "統合中..."
 msgid "Name"
 msgstr "名前"
 
-#: app/albums/new.tsx:65 app/albums/new.tsx:150
-msgid "New album"
-msgstr ""
-
-#: app/artists/new.tsx:65 app/artists/new.tsx:150
-msgid "New artist"
-msgstr ""
-
-#: app/albums/[id].tsx:48
-msgid "No album found"
-msgstr ""
-
 #: app/artists/[id].tsx:48
 msgid "No artist found"
 msgstr "アーティストが見つかりません"
-
-#: app/albums/new.tsx:87
-msgid "Nombre del albuma"
-msgstr ""
 
 #: app/artists/new.tsx:87
 msgid "Nombre del artista"
@@ -215,10 +147,6 @@ msgstr "最近再生した曲"
 msgid "Remove from favorites"
 msgstr "お気に入りから削除"
 
-#: app/albums/edit/[id].tsx:234
-msgid "Same album?"
-msgstr ""
-
 #: app/artists/edit/[id].tsx:234
 msgid "Same artist?"
 msgstr "同じアーティストですか？"
@@ -239,10 +167,6 @@ msgstr "保存中..."
 msgid "Search songs"
 msgstr "曲を検索"
 
-#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
-msgid "Select an option"
-msgstr ""
-
 #: utils/pickAndImportDB.ts:17
 msgid "Selection canceled"
 msgstr "選択をキャンセルしました"
@@ -251,22 +175,10 @@ msgstr "選択をキャンセルしました"
 msgid "Settings"
 msgstr "設定"
 
-#: app/song/edit/[id].tsx:96
-msgid "Song name"
-msgstr ""
-
-#: app/song/edit/[id].tsx:75
-msgid "Song update"
-msgstr ""
-
 #: app/albums/[id].tsx:88 app/artists/[id].tsx:88
 #: components/partials/Heading.tsx:35
 msgid "Songs"
 msgstr "曲"
-
-#: app/albums/edit/[id].tsx:177
-msgid "The albums have been merged successfully"
-msgstr ""
 
 #: app/artists/edit/[id].tsx:177
 msgid "The artists have been merged successfully"
@@ -275,20 +187,6 @@ msgstr "アーティストは正常に統合されました"
 #: app/artists/edit/[id].tsx:43 app/artists/new.tsx:29
 msgid "The name must have at least 2 characters"
 msgstr "名前は2文字以上である必要があります"
-
-#: app/song/edit/[id].tsx:76
-msgid "The song has been updated correctly"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
-msgid "The title must have at least 2 characters"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:237
-msgid ""
-"These albums share the same title because Android reads it from the ID3 "
-"tags, which you can edit in Lissn."
-msgstr ""
 
 #: app/artists/edit/[id].tsx:237
 msgid ""
@@ -312,6 +210,109 @@ msgstr "長すぎます"
 #: components/partials/DrawerContent.tsx:36
 msgid "Your music app"
 msgstr "あなたの音楽アプリ"
+
+#: app/albums/new.tsx:66
+msgid "Album created successfully"
+msgstr "アルバムが正常に作成されました"
+
+#: app/albums/edit/[id].tsx:93
+msgid "Album name"
+msgstr "アルバム名"
+
+#: components/partials/DrawerContent.tsx:44
+msgid "Albums"
+msgstr "アルバム"
+
+#: app/albums/edit/[id].tsx:176
+msgid "Albums merged"
+msgstr "アルバムを統合しました"
+
+#: components/partials/SongInfo.tsx:189
+msgid "Are you sure you want to delete the song?"
+msgstr "本当にこの曲を削除しますか？"
+
+#: app/artists/new.tsx:66
+msgid "Artist created successfully"
+msgstr "アーティストが正常に作成されました"
+
+#: app/artists/edit/[id].tsx:93
+msgid "Artist name"
+msgstr "アーティスト名"
+
+#: app/song/edit/[id].tsx:187
+msgid "Create new album"
+msgstr "新しいアルバムを作成"
+
+#: app/song/edit/[id].tsx:156
+msgid "Create new artist"
+msgstr "新しいアーティストを作成"
+
+#: components/partials/SongInfo.tsx:206
+msgid "Delete"
+msgstr "削除"
+
+#: app/albums/edit/[id].tsx:208
+msgid "Edit album"
+msgstr "アルバムを編集"
+
+#: app/song/edit/[id].tsx:245
+msgid "Edit song"
+msgstr "曲を編集"
+
+#: app/albums/edit/[id].tsx:279
+msgid "Merge albums"
+msgstr "アルバムを統合"
+
+#: app/albums/new.tsx:65 app/albums/new.tsx:150
+msgid "New album"
+msgstr "新しいアルバム"
+
+#: app/artists/new.tsx:65 app/artists/new.tsx:150
+msgid "New artist"
+msgstr "新しいアーティスト"
+
+#: app/albums/[id].tsx:48
+msgid "No album found"
+msgstr "アルバムが見つかりません"
+
+#: app/albums/new.tsx:87
+msgid "Nombre del albuma"
+msgstr "アルバム名"
+
+#: app/albums/edit/[id].tsx:234
+msgid "Same album?"
+msgstr "同じアルバムですか？"
+
+#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
+msgid "Select an option"
+msgstr "オプションを選択"
+
+#: app/song/edit/[id].tsx:96
+msgid "Song name"
+msgstr "曲名"
+
+#: app/song/edit/[id].tsx:75
+msgid "Song update"
+msgstr "曲の更新"
+
+#: app/albums/edit/[id].tsx:177
+msgid "The albums have been merged successfully"
+msgstr "アルバムは正常に統合されました"
+
+#: app/song/edit/[id].tsx:76
+msgid "The song has been updated correctly"
+msgstr "曲は正常に更新されました"
+
+#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
+msgid "The title must have at least 2 characters"
+msgstr "タイトルは2文字以上でなければなりません"
+
+#: app/albums/edit/[id].tsx:237
+msgid ""
+"These albums share the same title because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
+msgstr ""
+"これらのアルバムは同じタイトルを共有しています。Android が ID3 タグから読み取るためで、Lissn で編集できます。"
 
 #: components/partials/SongInfo.tsx:97
 #~ msgid "Tile"

--- a/locales/ko/messages.po
+++ b/locales/ko/messages.po
@@ -25,37 +25,9 @@ msgstr "재생목록에 추가"
 msgid "Album"
 msgstr "앨범"
 
-#: app/albums/new.tsx:66
-msgid "Album created successfully"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:93
-msgid "Album name"
-msgstr ""
-
-#: components/partials/DrawerContent.tsx:44
-msgid "Albums"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:176
-msgid "Albums merged"
-msgstr ""
-
-#: components/partials/SongInfo.tsx:189
-msgid "Are you sure you want to delete the song?"
-msgstr ""
-
 #: app/song/edit/[id].tsx:131 components/partials/SongInfo.tsx:108
 msgid "Artist"
 msgstr "아티스트"
-
-#: app/artists/new.tsx:66
-msgid "Artist created successfully"
-msgstr ""
-
-#: app/artists/edit/[id].tsx:93
-msgid "Artist name"
-msgstr ""
 
 #: components/partials/Heading.tsx:39
 msgid "Artists"
@@ -78,29 +50,13 @@ msgstr "아트워크 URL"
 msgid "Cancel"
 msgstr "취소"
 
-#: app/song/edit/[id].tsx:187
-msgid "Create new album"
-msgstr ""
-
-#: app/song/edit/[id].tsx:156
-msgid "Create new artist"
-msgstr ""
-
 #: utils/pickAndImportDB.ts:29
 msgid "Database imported successfully"
 msgstr "데이터베이스가 성공적으로 가져와졌습니다"
 
-#: components/partials/SongInfo.tsx:206
-msgid "Delete"
-msgstr ""
-
 #: components/partials/SongInfo.tsx:176 components/partials/SongInfo.tsx:186
 msgid "Delete song"
 msgstr "노래 삭제"
-
-#: app/albums/edit/[id].tsx:208
-msgid "Edit album"
-msgstr ""
 
 #: app/artists/edit/[id].tsx:208
 msgid "Edit artist"
@@ -109,10 +65,6 @@ msgstr "아티스트 편집"
 #: components/partials/SongInfo.tsx:167
 msgid "Edit details"
 msgstr "세부정보 편집"
-
-#: app/song/edit/[id].tsx:245
-msgid "Edit song"
-msgstr ""
 
 #. js-lingui-explicit-id
 #: utils/pickAndImportDB.ts:36
@@ -148,10 +100,6 @@ msgstr "최근 노래"
 msgid "Merge"
 msgstr "병합"
 
-#: app/albums/edit/[id].tsx:279
-msgid "Merge albums"
-msgstr ""
-
 #: app/artists/edit/[id].tsx:279
 msgid "Merge artists"
 msgstr "아티스트 병합"
@@ -169,25 +117,9 @@ msgstr "병합 중..."
 msgid "Name"
 msgstr "이름"
 
-#: app/albums/new.tsx:65 app/albums/new.tsx:150
-msgid "New album"
-msgstr ""
-
-#: app/artists/new.tsx:65 app/artists/new.tsx:150
-msgid "New artist"
-msgstr ""
-
-#: app/albums/[id].tsx:48
-msgid "No album found"
-msgstr ""
-
 #: app/artists/[id].tsx:48
 msgid "No artist found"
 msgstr "아티스트를 찾을 수 없습니다"
-
-#: app/albums/new.tsx:87
-msgid "Nombre del albuma"
-msgstr ""
 
 #: app/artists/new.tsx:87
 msgid "Nombre del artista"
@@ -215,10 +147,6 @@ msgstr "최근 재생"
 msgid "Remove from favorites"
 msgstr "즐겨찾기에서 제거"
 
-#: app/albums/edit/[id].tsx:234
-msgid "Same album?"
-msgstr ""
-
 #: app/artists/edit/[id].tsx:234
 msgid "Same artist?"
 msgstr "같은 아티스트인가요?"
@@ -239,10 +167,6 @@ msgstr "저장 중..."
 msgid "Search songs"
 msgstr "노래 검색"
 
-#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
-msgid "Select an option"
-msgstr ""
-
 #: utils/pickAndImportDB.ts:17
 msgid "Selection canceled"
 msgstr "선택이 취소되었습니다"
@@ -251,22 +175,10 @@ msgstr "선택이 취소되었습니다"
 msgid "Settings"
 msgstr "설정"
 
-#: app/song/edit/[id].tsx:96
-msgid "Song name"
-msgstr ""
-
-#: app/song/edit/[id].tsx:75
-msgid "Song update"
-msgstr ""
-
 #: app/albums/[id].tsx:88 app/artists/[id].tsx:88
 #: components/partials/Heading.tsx:35
 msgid "Songs"
 msgstr "노래"
-
-#: app/albums/edit/[id].tsx:177
-msgid "The albums have been merged successfully"
-msgstr ""
 
 #: app/artists/edit/[id].tsx:177
 msgid "The artists have been merged successfully"
@@ -275,20 +187,6 @@ msgstr "아티스트가 성공적으로 병합되었습니다"
 #: app/artists/edit/[id].tsx:43 app/artists/new.tsx:29
 msgid "The name must have at least 2 characters"
 msgstr "이름은 최소 두 글자여야 합니다"
-
-#: app/song/edit/[id].tsx:76
-msgid "The song has been updated correctly"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
-msgid "The title must have at least 2 characters"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:237
-msgid ""
-"These albums share the same title because Android reads it from the ID3 "
-"tags, which you can edit in Lissn."
-msgstr ""
 
 #: app/artists/edit/[id].tsx:237
 msgid ""
@@ -312,6 +210,109 @@ msgstr "너무 깁니다"
 #: components/partials/DrawerContent.tsx:36
 msgid "Your music app"
 msgstr "당신의 음악 앱"
+
+#: app/albums/new.tsx:66
+msgid "Album created successfully"
+msgstr "앨범이 성공적으로 생성되었습니다"
+
+#: app/albums/edit/[id].tsx:93
+msgid "Album name"
+msgstr "앨범 이름"
+
+#: components/partials/DrawerContent.tsx:44
+msgid "Albums"
+msgstr "앨범"
+
+#: app/albums/edit/[id].tsx:176
+msgid "Albums merged"
+msgstr "앨범이 병합되었습니다"
+
+#: components/partials/SongInfo.tsx:189
+msgid "Are you sure you want to delete the song?"
+msgstr "정말로 이 노래를 삭제하시겠습니까?"
+
+#: app/artists/new.tsx:66
+msgid "Artist created successfully"
+msgstr "아티스트가 성공적으로 생성되었습니다"
+
+#: app/artists/edit/[id].tsx:93
+msgid "Artist name"
+msgstr "아티스트 이름"
+
+#: app/song/edit/[id].tsx:187
+msgid "Create new album"
+msgstr "새 앨범 만들기"
+
+#: app/song/edit/[id].tsx:156
+msgid "Create new artist"
+msgstr "새 아티스트 만들기"
+
+#: components/partials/SongInfo.tsx:206
+msgid "Delete"
+msgstr "삭제"
+
+#: app/albums/edit/[id].tsx:208
+msgid "Edit album"
+msgstr "앨범 편집"
+
+#: app/song/edit/[id].tsx:245
+msgid "Edit song"
+msgstr "노래 편집"
+
+#: app/albums/edit/[id].tsx:279
+msgid "Merge albums"
+msgstr "앨범 병합"
+
+#: app/albums/new.tsx:65 app/albums/new.tsx:150
+msgid "New album"
+msgstr "새 앨범"
+
+#: app/artists/new.tsx:65 app/artists/new.tsx:150
+msgid "New artist"
+msgstr "새 아티스트"
+
+#: app/albums/[id].tsx:48
+msgid "No album found"
+msgstr "앨범을 찾을 수 없습니다"
+
+#: app/albums/new.tsx:87
+msgid "Nombre del albuma"
+msgstr "앨범 이름"
+
+#: app/albums/edit/[id].tsx:234
+msgid "Same album?"
+msgstr "같은 앨범인가요?"
+
+#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
+msgid "Select an option"
+msgstr "옵션을 선택하세요"
+
+#: app/song/edit/[id].tsx:96
+msgid "Song name"
+msgstr "노래 이름"
+
+#: app/song/edit/[id].tsx:75
+msgid "Song update"
+msgstr "노래 업데이트"
+
+#: app/albums/edit/[id].tsx:177
+msgid "The albums have been merged successfully"
+msgstr "앨범이 성공적으로 병합되었습니다"
+
+#: app/song/edit/[id].tsx:76
+msgid "The song has been updated correctly"
+msgstr "노래가 성공적으로 업데이트되었습니다"
+
+#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
+msgid "The title must have at least 2 characters"
+msgstr "제목은 최소 2자 이상이어야 합니다"
+
+#: app/albums/edit/[id].tsx:237
+msgid ""
+"These albums share the same title because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
+msgstr ""
+"이 앨범들은 Android가 ID3 태그에서 읽어오기 때문에 동일한 제목을 공유하며, Lissn에서 수정할 수 있습니다."
 
 #: components/partials/SongInfo.tsx:97
 #~ msgid "Tile"

--- a/locales/zh/messages.po
+++ b/locales/zh/messages.po
@@ -25,37 +25,9 @@ msgstr "添加到播放列表"
 msgid "Album"
 msgstr "专辑"
 
-#: app/albums/new.tsx:66
-msgid "Album created successfully"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:93
-msgid "Album name"
-msgstr ""
-
-#: components/partials/DrawerContent.tsx:44
-msgid "Albums"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:176
-msgid "Albums merged"
-msgstr ""
-
-#: components/partials/SongInfo.tsx:189
-msgid "Are you sure you want to delete the song?"
-msgstr ""
-
 #: app/song/edit/[id].tsx:131 components/partials/SongInfo.tsx:108
 msgid "Artist"
 msgstr "艺术家"
-
-#: app/artists/new.tsx:66
-msgid "Artist created successfully"
-msgstr ""
-
-#: app/artists/edit/[id].tsx:93
-msgid "Artist name"
-msgstr ""
 
 #: components/partials/Heading.tsx:39
 msgid "Artists"
@@ -78,29 +50,13 @@ msgstr "封面网址"
 msgid "Cancel"
 msgstr "取消"
 
-#: app/song/edit/[id].tsx:187
-msgid "Create new album"
-msgstr ""
-
-#: app/song/edit/[id].tsx:156
-msgid "Create new artist"
-msgstr ""
-
 #: utils/pickAndImportDB.ts:29
 msgid "Database imported successfully"
 msgstr "数据库导入成功"
 
-#: components/partials/SongInfo.tsx:206
-msgid "Delete"
-msgstr ""
-
 #: components/partials/SongInfo.tsx:176 components/partials/SongInfo.tsx:186
 msgid "Delete song"
 msgstr "删除歌曲"
-
-#: app/albums/edit/[id].tsx:208
-msgid "Edit album"
-msgstr ""
 
 #: app/artists/edit/[id].tsx:208
 msgid "Edit artist"
@@ -109,10 +65,6 @@ msgstr "编辑艺术家"
 #: components/partials/SongInfo.tsx:167
 msgid "Edit details"
 msgstr "编辑详情"
-
-#: app/song/edit/[id].tsx:245
-msgid "Edit song"
-msgstr ""
 
 #. js-lingui-explicit-id
 #: utils/pickAndImportDB.ts:36
@@ -148,10 +100,6 @@ msgstr "最近的歌曲"
 msgid "Merge"
 msgstr "合并"
 
-#: app/albums/edit/[id].tsx:279
-msgid "Merge albums"
-msgstr ""
-
 #: app/artists/edit/[id].tsx:279
 msgid "Merge artists"
 msgstr "合并艺术家"
@@ -169,25 +117,9 @@ msgstr "正在合并..."
 msgid "Name"
 msgstr "名称"
 
-#: app/albums/new.tsx:65 app/albums/new.tsx:150
-msgid "New album"
-msgstr ""
-
-#: app/artists/new.tsx:65 app/artists/new.tsx:150
-msgid "New artist"
-msgstr ""
-
-#: app/albums/[id].tsx:48
-msgid "No album found"
-msgstr ""
-
 #: app/artists/[id].tsx:48
 msgid "No artist found"
 msgstr "未找到艺术家"
-
-#: app/albums/new.tsx:87
-msgid "Nombre del albuma"
-msgstr ""
 
 #: app/artists/new.tsx:87
 msgid "Nombre del artista"
@@ -215,10 +147,6 @@ msgstr "最近播放"
 msgid "Remove from favorites"
 msgstr "从收藏中移除"
 
-#: app/albums/edit/[id].tsx:234
-msgid "Same album?"
-msgstr ""
-
 #: app/artists/edit/[id].tsx:234
 msgid "Same artist?"
 msgstr "相同的艺术家？"
@@ -239,10 +167,6 @@ msgstr "正在保存..."
 msgid "Search songs"
 msgstr "搜索歌曲"
 
-#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
-msgid "Select an option"
-msgstr ""
-
 #: utils/pickAndImportDB.ts:17
 msgid "Selection canceled"
 msgstr "选择已取消"
@@ -251,22 +175,10 @@ msgstr "选择已取消"
 msgid "Settings"
 msgstr "设置"
 
-#: app/song/edit/[id].tsx:96
-msgid "Song name"
-msgstr ""
-
-#: app/song/edit/[id].tsx:75
-msgid "Song update"
-msgstr ""
-
 #: app/albums/[id].tsx:88 app/artists/[id].tsx:88
 #: components/partials/Heading.tsx:35
 msgid "Songs"
 msgstr "歌曲"
-
-#: app/albums/edit/[id].tsx:177
-msgid "The albums have been merged successfully"
-msgstr ""
 
 #: app/artists/edit/[id].tsx:177
 msgid "The artists have been merged successfully"
@@ -275,20 +187,6 @@ msgstr "艺术家已成功合并"
 #: app/artists/edit/[id].tsx:43 app/artists/new.tsx:29
 msgid "The name must have at least 2 characters"
 msgstr "名称至少需要2个字符"
-
-#: app/song/edit/[id].tsx:76
-msgid "The song has been updated correctly"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
-msgid "The title must have at least 2 characters"
-msgstr ""
-
-#: app/albums/edit/[id].tsx:237
-msgid ""
-"These albums share the same title because Android reads it from the ID3 "
-"tags, which you can edit in Lissn."
-msgstr ""
 
 #: app/artists/edit/[id].tsx:237
 msgid ""
@@ -312,6 +210,109 @@ msgstr "太长"
 #: components/partials/DrawerContent.tsx:36
 msgid "Your music app"
 msgstr "你的音乐应用"
+
+#: app/albums/new.tsx:66
+msgid "Album created successfully"
+msgstr "专辑创建成功"
+
+#: app/albums/edit/[id].tsx:93
+msgid "Album name"
+msgstr "专辑名称"
+
+#: components/partials/DrawerContent.tsx:44
+msgid "Albums"
+msgstr "专辑"
+
+#: app/albums/edit/[id].tsx:176
+msgid "Albums merged"
+msgstr "专辑合并成功"
+
+#: components/partials/SongInfo.tsx:189
+msgid "Are you sure you want to delete the song?"
+msgstr "确定要删除这首歌吗？"
+
+#: app/artists/new.tsx:66
+msgid "Artist created successfully"
+msgstr "艺术家创建成功"
+
+#: app/artists/edit/[id].tsx:93
+msgid "Artist name"
+msgstr "艺术家名称"
+
+#: app/song/edit/[id].tsx:187
+msgid "Create new album"
+msgstr "创建新专辑"
+
+#: app/song/edit/[id].tsx:156
+msgid "Create new artist"
+msgstr "创建新艺术家"
+
+#: components/partials/SongInfo.tsx:206
+msgid "Delete"
+msgstr "删除"
+
+#: app/albums/edit/[id].tsx:208
+msgid "Edit album"
+msgstr "编辑专辑"
+
+#: app/song/edit/[id].tsx:245
+msgid "Edit song"
+msgstr "编辑歌曲"
+
+#: app/albums/edit/[id].tsx:279
+msgid "Merge albums"
+msgstr "合并专辑"
+
+#: app/albums/new.tsx:65 app/albums/new.tsx:150
+msgid "New album"
+msgstr "新专辑"
+
+#: app/artists/new.tsx:65 app/artists/new.tsx:150
+msgid "New artist"
+msgstr "新艺术家"
+
+#: app/albums/[id].tsx:48
+msgid "No album found"
+msgstr "未找到专辑"
+
+#: app/albums/new.tsx:87
+msgid "Nombre del albuma"
+msgstr "专辑名称"
+
+#: app/albums/edit/[id].tsx:234
+msgid "Same album?"
+msgstr "同一个专辑？"
+
+#: components/ui/Select.tsx:54 components/ui/Select.tsx:105
+msgid "Select an option"
+msgstr "选择一个选项"
+
+#: app/song/edit/[id].tsx:96
+msgid "Song name"
+msgstr "歌曲名称"
+
+#: app/song/edit/[id].tsx:75
+msgid "Song update"
+msgstr "歌曲更新"
+
+#: app/albums/edit/[id].tsx:177
+msgid "The albums have been merged successfully"
+msgstr "专辑已成功合并"
+
+#: app/song/edit/[id].tsx:76
+msgid "The song has been updated correctly"
+msgstr "歌曲已成功更新"
+
+#: app/albums/edit/[id].tsx:43 app/albums/new.tsx:29 app/song/edit/[id].tsx:33
+msgid "The title must have at least 2 characters"
+msgstr "标题至少需要 2 个字符"
+
+#: app/albums/edit/[id].tsx:237
+msgid ""
+"These albums share the same title because Android reads it from the ID3 "
+"tags, which you can edit in Lissn."
+msgstr ""
+"这些专辑共享同一标题，因为 Android 从 ID3 标签读取它，你可以在 Lissn 中编辑。"
 
 #: components/partials/SongInfo.tsx:97
 #~ msgid "Tile"


### PR DESCRIPTION
## Summary
- Translate previously placeholder English msgstr entries in all non-English `.po` files.
- Provide proper localized text for Arabic, German, Spanish, French, Hindi, Italian, Japanese, Korean, and Chinese locales.

## Testing
- `msgfmt -c locales/ar/messages.po -o /dev/null`
- `msgfmt -c locales/de/messages.po -o /dev/null`
- `msgfmt -c locales/es/messages.po -o /dev/null`
- `msgfmt -c locales/fr/messages.po -o /dev/null`
- `msgfmt -c locales/hi/messages.po -o /dev/null`
- `msgfmt -c locales/it/messages.po -o /dev/null`
- `msgfmt -c locales/ja/messages.po -o /dev/null`
- `msgfmt -c locales/ko/messages.po -o /dev/null`
- `msgfmt -c locales/zh/messages.po -o /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_68ac089db5d08330a4bc61adac2c2454