### PR TITLE
chore: i18n - translate empty msgstr in .po

### DIFF
--- a/locales/ar/messages.po
+++ b/locales/ar/messages.po
@@ -279,15 +279,15 @@ msgstr "جارٍ الحفظ..."
 
 #: components/partials/Heading.tsx:99
 msgid "Search"
-msgstr "Search"
+msgstr "بحث"
 
 #: components/partials/Heading.tsx:97
 msgid "Search artists"
-msgstr "Search artists"
+msgstr "البحث عن الفنانين"
 
 #: components/partials/Heading.tsx:95
 msgid "Search favorite songs"
-msgstr "Search favorite songs"
+msgstr "البحث عن الأغاني المفضلة"
 
 #: components/partials/Heading.tsx:93
 msgid "Search songs"

--- a/locales/ar/messages.po
+++ b/locales/ar/messages.po
@@ -279,15 +279,15 @@ msgstr "جارٍ الحفظ..."
 
 #: components/partials/Heading.tsx:99
 msgid "Search"
-msgstr ""
+msgstr "Search"
 
 #: components/partials/Heading.tsx:97
 msgid "Search artists"
-msgstr ""
+msgstr "Search artists"
 
 #: components/partials/Heading.tsx:95
 msgid "Search favorite songs"
-msgstr ""
+msgstr "Search favorite songs"
 
 #: components/partials/Heading.tsx:93
 msgid "Search songs"

--- a/locales/de/messages.po
+++ b/locales/de/messages.po
@@ -279,15 +279,15 @@ msgstr "Speichern..."
 
 #: components/partials/Heading.tsx:99
 msgid "Search"
-msgstr ""
+msgstr "Search"
 
 #: components/partials/Heading.tsx:97
 msgid "Search artists"
-msgstr ""
+msgstr "Search artists"
 
 #: components/partials/Heading.tsx:95
 msgid "Search favorite songs"
-msgstr ""
+msgstr "Search favorite songs"
 
 #: components/partials/Heading.tsx:93
 msgid "Search songs"

--- a/locales/de/messages.po
+++ b/locales/de/messages.po
@@ -279,15 +279,15 @@ msgstr "Speichern..."
 
 #: components/partials/Heading.tsx:99
 msgid "Search"
-msgstr "Search"
+msgstr "Suchen"
 
 #: components/partials/Heading.tsx:97
 msgid "Search artists"
-msgstr "Search artists"
+msgstr "Künstler suchen"
 
 #: components/partials/Heading.tsx:95
 msgid "Search favorite songs"
-msgstr "Search favorite songs"
+msgstr "Lieblingssongs suchen"
 
 #: components/partials/Heading.tsx:93
 msgid "Search songs"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -279,15 +279,15 @@ msgstr "Guardando..."
 
 #: components/partials/Heading.tsx:99
 msgid "Search"
-msgstr "Search"
+msgstr "Buscar"
 
 #: components/partials/Heading.tsx:97
 msgid "Search artists"
-msgstr "Search artists"
+msgstr "Buscar artistas"
 
 #: components/partials/Heading.tsx:95
 msgid "Search favorite songs"
-msgstr "Search favorite songs"
+msgstr "Buscar canciones favoritas"
 
 #: components/partials/Heading.tsx:93
 msgid "Search songs"

--- a/locales/es/messages.po
+++ b/locales/es/messages.po
@@ -279,15 +279,15 @@ msgstr "Guardando..."
 
 #: components/partials/Heading.tsx:99
 msgid "Search"
-msgstr ""
+msgstr "Search"
 
 #: components/partials/Heading.tsx:97
 msgid "Search artists"
-msgstr ""
+msgstr "Search artists"
 
 #: components/partials/Heading.tsx:95
 msgid "Search favorite songs"
-msgstr ""
+msgstr "Search favorite songs"
 
 #: components/partials/Heading.tsx:93
 msgid "Search songs"

--- a/locales/fr/messages.po
+++ b/locales/fr/messages.po
@@ -279,15 +279,15 @@ msgstr "Enregistrement..."
 
 #: components/partials/Heading.tsx:99
 msgid "Search"
-msgstr ""
+msgstr "Search"
 
 #: components/partials/Heading.tsx:97
 msgid "Search artists"
-msgstr ""
+msgstr "Search artists"
 
 #: components/partials/Heading.tsx:95
 msgid "Search favorite songs"
-msgstr ""
+msgstr "Search favorite songs"
 
 #: components/partials/Heading.tsx:93
 msgid "Search songs"

--- a/locales/fr/messages.po
+++ b/locales/fr/messages.po
@@ -279,15 +279,15 @@ msgstr "Enregistrement..."
 
 #: components/partials/Heading.tsx:99
 msgid "Search"
-msgstr "Search"
+msgstr "Rechercher"
 
 #: components/partials/Heading.tsx:97
 msgid "Search artists"
-msgstr "Search artists"
+msgstr "Rechercher des artistes"
 
 #: components/partials/Heading.tsx:95
 msgid "Search favorite songs"
-msgstr "Search favorite songs"
+msgstr "Rechercher des chansons favorites"
 
 #: components/partials/Heading.tsx:93
 msgid "Search songs"

--- a/locales/hi/messages.po
+++ b/locales/hi/messages.po
@@ -279,15 +279,15 @@ msgstr "सहेजा जा रहा है..."
 
 #: components/partials/Heading.tsx:99
 msgid "Search"
-msgstr ""
+msgstr "Search"
 
 #: components/partials/Heading.tsx:97
 msgid "Search artists"
-msgstr ""
+msgstr "Search artists"
 
 #: components/partials/Heading.tsx:95
 msgid "Search favorite songs"
-msgstr ""
+msgstr "Search favorite songs"
 
 #: components/partials/Heading.tsx:93
 msgid "Search songs"

--- a/locales/hi/messages.po
+++ b/locales/hi/messages.po
@@ -279,15 +279,15 @@ msgstr "सहेजा जा रहा है..."
 
 #: components/partials/Heading.tsx:99
 msgid "Search"
-msgstr "Search"
+msgstr "खोजें"
 
 #: components/partials/Heading.tsx:97
 msgid "Search artists"
-msgstr "Search artists"
+msgstr "कलाकार खोजें"
 
 #: components/partials/Heading.tsx:95
 msgid "Search favorite songs"
-msgstr "Search favorite songs"
+msgstr "पसंदीदा गीत खोजें"
 
 #: components/partials/Heading.tsx:93
 msgid "Search songs"

--- a/locales/it/messages.po
+++ b/locales/it/messages.po
@@ -279,15 +279,15 @@ msgstr "Salvataggio..."
 
 #: components/partials/Heading.tsx:99
 msgid "Search"
-msgstr "Search"
+msgstr "Cerca"
 
 #: components/partials/Heading.tsx:97
 msgid "Search artists"
-msgstr "Search artists"
+msgstr "Cerca artisti"
 
 #: components/partials/Heading.tsx:95
 msgid "Search favorite songs"
-msgstr "Search favorite songs"
+msgstr "Cerca canzoni preferite"
 
 #: components/partials/Heading.tsx:93
 msgid "Search songs"

--- a/locales/it/messages.po
+++ b/locales/it/messages.po
@@ -279,15 +279,15 @@ msgstr "Salvataggio..."
 
 #: components/partials/Heading.tsx:99
 msgid "Search"
-msgstr ""
+msgstr "Search"
 
 #: components/partials/Heading.tsx:97
 msgid "Search artists"
-msgstr ""
+msgstr "Search artists"
 
 #: components/partials/Heading.tsx:95
 msgid "Search favorite songs"
-msgstr ""
+msgstr "Search favorite songs"
 
 #: components/partials/Heading.tsx:93
 msgid "Search songs"

--- a/locales/ja/messages.po
+++ b/locales/ja/messages.po
@@ -279,15 +279,15 @@ msgstr "保存中..."
 
 #: components/partials/Heading.tsx:99
 msgid "Search"
-msgstr ""
+msgstr "Search"
 
 #: components/partials/Heading.tsx:97
 msgid "Search artists"
-msgstr ""
+msgstr "Search artists"
 
 #: components/partials/Heading.tsx:95
 msgid "Search favorite songs"
-msgstr ""
+msgstr "Search favorite songs"
 
 #: components/partials/Heading.tsx:93
 msgid "Search songs"

--- a/locales/ja/messages.po
+++ b/locales/ja/messages.po
@@ -279,15 +279,15 @@ msgstr "保存中..."
 
 #: components/partials/Heading.tsx:99
 msgid "Search"
-msgstr "Search"
+msgstr "検索"
 
 #: components/partials/Heading.tsx:97
 msgid "Search artists"
-msgstr "Search artists"
+msgstr "アーティストを検索"
 
 #: components/partials/Heading.tsx:95
 msgid "Search favorite songs"
-msgstr "Search favorite songs"
+msgstr "お気に入りの曲を検索"
 
 #: components/partials/Heading.tsx:93
 msgid "Search songs"

--- a/locales/ko/messages.po
+++ b/locales/ko/messages.po
@@ -279,15 +279,15 @@ msgstr "저장 중..."
 
 #: components/partials/Heading.tsx:99
 msgid "Search"
-msgstr ""
+msgstr "Search"
 
 #: components/partials/Heading.tsx:97
 msgid "Search artists"
-msgstr ""
+msgstr "Search artists"
 
 #: components/partials/Heading.tsx:95
 msgid "Search favorite songs"
-msgstr ""
+msgstr "Search favorite songs"
 
 #: components/partials/Heading.tsx:93
 msgid "Search songs"

--- a/locales/ko/messages.po
+++ b/locales/ko/messages.po
@@ -279,15 +279,15 @@ msgstr "저장 중..."
 
 #: components/partials/Heading.tsx:99
 msgid "Search"
-msgstr "Search"
+msgstr "검색"
 
 #: components/partials/Heading.tsx:97
 msgid "Search artists"
-msgstr "Search artists"
+msgstr "아티스트 검색"
 
 #: components/partials/Heading.tsx:95
 msgid "Search favorite songs"
-msgstr "Search favorite songs"
+msgstr "즐겨찾는 노래 검색"
 
 #: components/partials/Heading.tsx:93
 msgid "Search songs"

--- a/locales/zh/messages.po
+++ b/locales/zh/messages.po
@@ -279,15 +279,15 @@ msgstr "正在保存..."
 
 #: components/partials/Heading.tsx:99
 msgid "Search"
-msgstr "Search"
+msgstr "搜索"
 
 #: components/partials/Heading.tsx:97
 msgid "Search artists"
-msgstr "Search artists"
+msgstr "搜索艺术家"
 
 #: components/partials/Heading.tsx:95
 msgid "Search favorite songs"
-msgstr "Search favorite songs"
+msgstr "搜索收藏的歌曲"
 
 #: components/partials/Heading.tsx:93
 msgid "Search songs"

--- a/locales/zh/messages.po
+++ b/locales/zh/messages.po
@@ -279,15 +279,15 @@ msgstr "正在保存..."
 
 #: components/partials/Heading.tsx:99
 msgid "Search"
-msgstr ""
+msgstr "Search"
 
 #: components/partials/Heading.tsx:97
 msgid "Search artists"
-msgstr ""
+msgstr "Search artists"
 
 #: components/partials/Heading.tsx:95
 msgid "Search favorite songs"
-msgstr ""
+msgstr "Search favorite songs"
 
 #: components/partials/Heading.tsx:93
 msgid "Search songs"


### PR DESCRIPTION
Updates non-English .po files to translate previously empty msgstr for search-related strings (Search, Search artists, Search favorite songs) following each locale’s style.\n\n- Branch: chore/i18n-fill-empty-msgstr\n- Commits:\n  - i18n(po): fill empty msgstr with msgid for non-English locales\n  - i18n(po): translate empty search strings per locale